### PR TITLE
Validate virtual cluster name attribute

### DIFF
--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
 )
 
@@ -106,6 +107,7 @@ func (d *virtualClusterDataSource) Read(ctx context.Context, req datasource.Read
 		)
 		return
 	}
+	tflog.Debug(ctx, fmt.Sprintf("Virtual Cluster: %+v", *vc))
 
 	// Map response body to model
 	state := virtualClusterModel{
@@ -114,6 +116,7 @@ func (d *virtualClusterDataSource) Read(ctx context.Context, req datasource.Read
 		AgentPoolID:   types.StringValue(vc.AgentPoolID),
 		AgentPoolName: types.StringValue(vc.AgentPoolName),
 		CreatedAt:     types.StringValue(vc.CreatedAt),
+		Configuration: data.Configuration,
 	}
 
 	// Set state

--- a/internal/provider/virtual_cluster_data_source_test.go
+++ b/internal/provider/virtual_cluster_data_source_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccVirtualClusterDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVirtualClusterDataSource_default(),
+				Check:  testAccVirtualClusterDataSourceCheck("default"),
+			},
+		},
+	})
+}
+
+func testAccVirtualClusterDataSource_default() string {
+	return providerConfig + `
+data "warpstream_virtual_cluster" "test" {
+  default = true
+}`
+}
+
+func testAccVirtualClusterDataSourceCheck(name string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrSet("data.warpstream_virtual_cluster.test", "id"),
+		resource.TestCheckResourceAttrSet("data.warpstream_virtual_cluster.test", "agent_pool_id"),
+		resource.TestCheckResourceAttrSet("data.warpstream_virtual_cluster.test", "created_at"),
+		resource.TestCheckResourceAttr("data.warpstream_virtual_cluster.test", "agent_pool_name", "apn_"+name),
+	)
+}

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -81,6 +84,12 @@ This resource allows you to create, update and delete virtual clusters.
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^vcn_`),
+						"must start with 'vcn_' prefix",
+					),
 				},
 			},
 			"agent_pool_id": schema.StringAttribute{


### PR DESCRIPTION
- Make sure the provided `name` attribute does start with `vcn_`
- Add regression test for `warpstream_virtual_cluster` data source
- Patch `warpstream_virtual_cluster` data source (missing configuration object)