### PR TITLE
Catch internal server errors

### DIFF
--- a/internal/provider/account_data_source.go
+++ b/internal/provider/account_data_source.go
@@ -78,7 +78,6 @@ func (d *accountDataSource) Configure(_ context.Context, req datasource.Configur
 			"Unexpected Data Source Configure Type",
 			fmt.Sprintf("Expected *api.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
-
 		return
 	}
 

--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -61,6 +62,10 @@ func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error)
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status: %d, body: %s", res.StatusCode, body)
+	}
+
+	if strings.Contains(string(body), "internal server error") {
+		return nil, fmt.Errorf("status: 500, body: internal server error")
 	}
 
 	return body, err

--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -3,7 +3,9 @@ package api
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"net/http/httputil"
 	"strings"
 	"time"
 )
@@ -40,6 +42,12 @@ func NewClient(host string, token *string) (*Client, error) {
 }
 
 func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error) {
+	d, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, fmt.Errorf("internal client error: %s", err)
+	}
+	log.Printf("%q\n", d)
+
 	token := c.Token
 
 	if authToken != nil {
@@ -59,6 +67,7 @@ func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("%q\n", body)
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status: %d, body: %s", res.StatusCode, body)

--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -133,6 +133,7 @@ func (d *virtualClusterDataSource) Read(ctx context.Context, req datasource.Read
 			"Unable to Read configuration of Virtual Cluster with ID="+vc.ID,
 			err.Error(),
 		)
+		return
 	}
 
 	cfgState := virtualClusterConfigurationModel{
@@ -159,7 +160,6 @@ func (d *virtualClusterDataSource) Configure(_ context.Context, req datasource.C
 			"Unexpected Data Source Configure Type",
 			fmt.Sprintf("Expected *api.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
-
 		return
 	}
 

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -298,6 +298,7 @@ func (r *virtualClusterResource) readConfiguration(ctx context.Context, cluster 
 			"Unable to Read configuration of Virtual Cluster with ID="+cluster.ID,
 			err.Error(),
 		)
+		return
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Configuration: %+v", *cfg))
 

--- a/internal/provider/virtual_clusters_data_source.go
+++ b/internal/provider/virtual_clusters_data_source.go
@@ -121,7 +121,6 @@ func (d *virtualClustersDataSource) Configure(_ context.Context, req datasource.
 			"Unexpected Data Source Configure Type",
 			fmt.Sprintf("Expected *api.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
-
 		return
 	}
 


### PR DESCRIPTION
In some cases, the WarpStream API will return a 200 response with the following body
```
{"code": "internal", "message": "internal server error"}
```
that we need to treat as an API error instead of an issue in the provider.

Logging is added to the HTTP client (pass `TF_LOG=DEBUG` to display the messages).