### PR TITLE
Add Virtual Cluster Configuration: default retention 

### DIFF
--- a/docs/data-sources/virtual_cluster.md
+++ b/docs/data-sources/virtual_cluster.md
@@ -54,4 +54,5 @@ Read-Only:
 
 - `auto_create_topic` (Boolean)
 - `default_num_partitions` (Number)
+- `default_retention_millis` (Number)
 - `enable_acls` (Boolean)

--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -32,9 +32,10 @@ resource "warpstream_virtual_cluster" "test_with_acls" {
 resource "warpstream_virtual_cluster" "test_configuration" {
   name = "vcn_test_configuration"
   configuration = {
-    default_num_partitions = 1
-    auto_create_topic      = true
-    enable_acls            = true
+    auto_create_topic        = true
+    default_num_partitions   = 1
+    default_retention_millis = 86400000
+    enable_acls              = true
   }
 }
 ```
@@ -66,6 +67,7 @@ Optional:
 
 - `auto_create_topic` (Boolean) Enable topic autocreation feature, defaults to `true`.
 - `default_num_partitions` (Number) Number of partitions created by default.
+- `default_retention_millis` (Number) Default retention for topics that are created automatically using Kafka's topic auto-creation feature.
 - `enable_acls` (Boolean) Enable ACLs, defaults to `false`. See [Configure ACLs](https://docs.warpstream.com/warpstream/configuration/configure-acls)
 
 ## Import

--- a/examples/resources/warpstream_virtual_cluster/resource.tf
+++ b/examples/resources/warpstream_virtual_cluster/resource.tf
@@ -17,8 +17,9 @@ resource "warpstream_virtual_cluster" "test_with_acls" {
 resource "warpstream_virtual_cluster" "test_configuration" {
   name = "vcn_test_configuration"
   configuration = {
-    default_num_partitions = 1
-    auto_create_topic      = true
-    enable_acls            = true
+    auto_create_topic        = true
+    default_num_partitions   = 1
+    default_retention_millis = 86400000
+    enable_acls              = true
   }
 }

--- a/internal/provider/api/models.go
+++ b/internal/provider/api/models.go
@@ -21,7 +21,8 @@ type VirtualClusterCredentials struct {
 }
 
 type VirtualClusterConfiguration struct {
-	AclsEnabled          bool  `json:"are_acls_enabled"`
-	AutoCreateTopic      bool  `json:"is_auto_create_topic_enabled"`
-	DefaultNumPartitions int64 `json:"default_num_partitions"`
+	AclsEnabled            bool  `json:"are_acls_enabled"`
+	AutoCreateTopic        bool  `json:"is_auto_create_topic_enabled"`
+	DefaultNumPartitions   int64 `json:"default_num_partitions"`
+	DefaultRetentionMillis int64 `json:"default_retention_millis"`
 }

--- a/internal/provider/virtual_cluster.go
+++ b/internal/provider/virtual_cluster.go
@@ -21,20 +21,23 @@ type virtualClusterConfigurationModel struct {
 	AclsEnabled          types.Bool  `tfsdk:"enable_acls"`
 	AutoCreateTopic      types.Bool  `tfsdk:"auto_create_topic"`
 	DefaultNumPartitions types.Int64 `tfsdk:"default_num_partitions"`
+	DefaultRetention     types.Int64 `tfsdk:"default_retention_millis"`
 }
 
 func (m virtualClusterConfigurationModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"auto_create_topic":      types.BoolType,
-		"default_num_partitions": types.Int64Type,
-		"enable_acls":            types.BoolType,
+		"auto_create_topic":        types.BoolType,
+		"default_num_partitions":   types.Int64Type,
+		"default_retention_millis": types.Int64Type,
+		"enable_acls":              types.BoolType,
 	}
 }
 
 func (m virtualClusterConfigurationModel) DefaultObject() map[string]attr.Value {
 	return map[string]attr.Value{
-		"auto_create_topic":      types.BoolValue(true),
-		"default_num_partitions": types.Int64Value(1),
-		"enable_acls":            types.BoolValue(false),
+		"auto_create_topic":        types.BoolValue(true),
+		"default_num_partitions":   types.Int64Value(1),
+		"default_retention_millis": types.Int64Value(86400000),
+		"enable_acls":              types.BoolValue(false),
 	}
 }

--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -69,6 +69,9 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 					"default_num_partitions": schema.Int64Attribute{
 						Computed: true,
 					},
+					"default_retention_millis": schema.Int64Attribute{
+						Computed: true,
+					},
 					"enable_acls": schema.BoolAttribute{
 						Computed: true,
 					},
@@ -147,7 +150,10 @@ func (d *virtualClusterDataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	cfgState := virtualClusterConfigurationModel{
-		AclsEnabled: types.BoolValue(cfg.AclsEnabled),
+		AclsEnabled:          types.BoolValue(cfg.AclsEnabled),
+		AutoCreateTopic:      types.BoolValue(cfg.AutoCreateTopic),
+		DefaultNumPartitions: types.Int64Value(cfg.DefaultNumPartitions),
+		DefaultRetention:     types.Int64Value(cfg.DefaultRetentionMillis),
 	}
 
 	// Set configuration state

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -148,6 +148,12 @@ This resource allows you to create, update and delete virtual clusters.
 						Computed:    true,
 						Default:     int64default.StaticInt64(1),
 					},
+					"default_retention_millis": schema.Int64Attribute{
+						Description: "Default retention for topics that are created automatically using Kafka's topic auto-creation feature.",
+						Optional:    true,
+						Computed:    true,
+						Default:     int64default.StaticInt64(86400000),
+					},
 					"enable_acls": schema.BoolAttribute{
 						Description: "Enable ACLs, defaults to `false`. See [Configure ACLs](https://docs.warpstream.com/warpstream/configuration/configure-acls)",
 						Optional:    true,
@@ -338,6 +344,7 @@ func (r *virtualClusterResource) readConfiguration(ctx context.Context, cluster 
 		AclsEnabled:          types.BoolValue(cfg.AclsEnabled),
 		AutoCreateTopic:      types.BoolValue(cfg.AutoCreateTopic),
 		DefaultNumPartitions: types.Int64Value(cfg.DefaultNumPartitions),
+		DefaultRetention:     types.Int64Value(cfg.DefaultRetentionMillis),
 	}
 
 	// Set configuration state
@@ -365,9 +372,10 @@ func (r *virtualClusterResource) applyConfiguration(ctx context.Context, plan vi
 
 	// Update virtual cluster configuration
 	cfg := &api.VirtualClusterConfiguration{
-		AclsEnabled:          cfgPlan.AclsEnabled.ValueBool(),
-		AutoCreateTopic:      cfgPlan.AutoCreateTopic.ValueBool(),
-		DefaultNumPartitions: cfgPlan.DefaultNumPartitions.ValueInt64(),
+		AclsEnabled:            cfgPlan.AclsEnabled.ValueBool(),
+		AutoCreateTopic:        cfgPlan.AutoCreateTopic.ValueBool(),
+		DefaultNumPartitions:   cfgPlan.DefaultNumPartitions.ValueInt64(),
+		DefaultRetentionMillis: cfgPlan.DefaultRetention.ValueInt64(),
 	}
 	err := r.client.UpdateConfiguration(*cfg, cluster)
 	if err != nil {

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -81,5 +81,6 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.enable_acls", fmt.Sprintf("%t", acls)),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.auto_create_topic", fmt.Sprintf("%t", autoTopic)),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_num_partitions", fmt.Sprintf("%d", numParts)),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_retention_millis", fmt.Sprintf("%d", 86400000)),
 	)
 }


### PR DESCRIPTION
This PR adds support for configuration `default_retention_millis`.

See https://docs.warpstream.com/warpstream/reference/api-reference/virtual-clusters/updateconfiguration