### PR TITLE
Include agent keys in virtual cluster resource

### DIFF
--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -63,6 +63,7 @@ resource "warpstream_virtual_cluster" "test_cloud_region" {
 
 ### Read-Only
 
+- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster. Null for Serverless clusters. (see [below for nested schema](#nestedatt--agent_keys))
 - `agent_pool_id` (String) Agent Pool ID.
 - `agent_pool_name` (String) Agent Pool Name.
 - `created_at` (String) Virtual Cluster Creation Timestamp.
@@ -87,6 +88,18 @@ Optional:
 - `default_num_partitions` (Number) Number of partitions created by default.
 - `default_retention_millis` (Number) Default retention for topics that are created automatically using Kafka's topic auto-creation feature.
 - `enable_acls` (Boolean) Enable ACLs, defaults to `false`. See [Configure ACLs](https://docs.warpstream.com/warpstream/configuration/configure-acls)
+
+
+<a id="nestedatt--agent_keys"></a>
+### Nested Schema for `agent_keys`
+
+Read-Only:
+
+- `created_at` (String)
+- `id` (String)
+- `key` (String, Sensitive)
+- `name` (String)
+- `virtual_cluster_id` (String)
 
 ## Import
 

--- a/internal/provider/virtual_cluster.go
+++ b/internal/provider/virtual_cluster.go
@@ -28,6 +28,7 @@ type virtualClusterResourceModel struct {
 	ID            types.String `tfsdk:"id"`
 	Name          types.String `tfsdk:"name"`
 	Type          types.String `tfsdk:"type"`
+	AgentKeys     types.List   `tfsdk:"agent_keys"`
 	AgentPoolID   types.String `tfsdk:"agent_pool_id"`
 	AgentPoolName types.String `tfsdk:"agent_pool_name"`
 	CreatedAt     types.String `tfsdk:"created_at"`

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -84,7 +84,7 @@ func testAccVirtualClusterResourceCheck_BYOC(acls bool, autoTopic bool, numParts
 			func(value string) error {
 				if !strings.HasPrefix(value, "akn_virtual_cluster_test_acc_") {
 					return fmt.Errorf(
-						"expected agent_pool_name to start with 'akn_virtual_cluster_test_acc_', got: %s", value,
+						"expected agent_keys.0.name to start with 'akn_virtual_cluster_test_acc_', got: %s", value,
 					)
 				}
 				return nil

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -73,6 +74,7 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "id"),
 		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_id"),
+		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_id"),
 		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "created_at"),
 		// Note: agent_pool_name is now equal to "apn_test_acc_"+nameSuffix + randomSuffix
 		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_name"),
@@ -82,5 +84,18 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.auto_create_topic", fmt.Sprintf("%t", autoTopic)),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_num_partitions", fmt.Sprintf("%d", numParts)),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_retention_millis", fmt.Sprintf("%d", 86400000)),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "agent_keys.#", "1"),
+		resource.TestCheckResourceAttrWith(
+			"warpstream_virtual_cluster.test",
+			"agent_keys.0.name",
+			func(value string) error {
+				if !strings.HasPrefix(value, "akn_virtual_cluster_test_acc_") {
+					return fmt.Errorf(
+						"expected agent_pool_name to start with 'akn_virtual_cluster_test_acc_', got: %s", value,
+					)
+				}
+				return nil
+			},
+		),
 	)
 }

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -15,7 +15,7 @@ func TestAccVirtualClusterResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVirtualClusterResource_withPartialConfiguration(false),
-				Check:  testAccVirtualClusterResourceCheck(false, true, 1),
+				Check:  testAccVirtualClusterResourceCheck_BYOC(false, true, 1),
 			},
 			{
 				Config: testAccVirtualClusterResource(),
@@ -27,7 +27,11 @@ func TestAccVirtualClusterResource(t *testing.T) {
 			},
 			{
 				Config: testAccVirtualClusterResource_withConfiguration(true, false, 2),
-				Check:  testAccVirtualClusterResourceCheck(true, false, 2),
+				Check:  testAccVirtualClusterResourceCheck_BYOC(true, false, 2),
+			},
+			{
+				Config: testAccVirtualClusterResource_withType("serverless"),
+				Check:  testAccVirtualClusterResourceCheck_Serverless(false, true, 1),
 			},
 		},
 	})
@@ -70,20 +74,9 @@ resource "warpstream_virtual_cluster" "test" {
 }`, nameSuffix, acls, numParts, autoTopic)
 }
 
-func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int64) resource.TestCheckFunc {
+func testAccVirtualClusterResourceCheck_BYOC(acls bool, autoTopic bool, numParts int64) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "id"),
-		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_id"),
-		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_id"),
-		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "created_at"),
-		// Note: agent_pool_name is now equal to "apn_test_acc_"+nameSuffix + randomSuffix
-		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_name"),
-		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "default", "false"),
-		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "type", "byoc"),
-		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.enable_acls", fmt.Sprintf("%t", acls)),
-		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.auto_create_topic", fmt.Sprintf("%t", autoTopic)),
-		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_num_partitions", fmt.Sprintf("%d", numParts)),
-		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_retention_millis", fmt.Sprintf("%d", 86400000)),
+		testAccVirtualClusterResourceCheck(acls, autoTopic, numParts, "byoc"),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "agent_keys.#", "1"),
 		resource.TestCheckResourceAttrWith(
 			"warpstream_virtual_cluster.test",
@@ -97,5 +90,29 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 				return nil
 			},
 		),
+	)
+}
+
+func testAccVirtualClusterResourceCheck_Serverless(acls bool, autoTopic bool, numParts int64) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		testAccVirtualClusterResourceCheck(acls, autoTopic, numParts, "serverless"),
+		resource.TestCheckNoResourceAttr("warpstream_virtual_cluster.test", "agent_keys"),
+	)
+}
+
+func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int64, vcType string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "id"),
+		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_id"),
+		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_id"),
+		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "created_at"),
+		// Note: agent_pool_name is now equal to "apn_test_acc_"+nameSuffix + randomSuffix
+		resource.TestCheckResourceAttrSet("warpstream_virtual_cluster.test", "agent_pool_name"),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "default", "false"),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "type", vcType),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.enable_acls", fmt.Sprintf("%t", acls)),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.auto_create_topic", fmt.Sprintf("%t", autoTopic)),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_num_partitions", fmt.Sprintf("%d", numParts)),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_retention_millis", fmt.Sprintf("%d", 86400000)),
 	)
 }


### PR DESCRIPTION
Before this we only showed agent keys in the virtual cluster and virtual clusters data sources (and in the agent key resource)