### PR TITLE
Fix .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
@@ -57,4 +59,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
See goreleaser changelog https://goreleaser.com/deprecations/#changelogskip

Also adding `version: 2` at the top made this error go away `only configurations files on  version: 2  are supported, yours is  version: 0`