### PR TITLE
Virtual cluster cloud config read

### DIFF
--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -342,8 +342,8 @@ func (r *virtualClusterResource) Read(ctx context.Context, req resource.ReadRequ
 	cloudValue, diagnostics := types.ObjectValue(
 		virtualClusterCloudModel{}.AttributeTypes(),
 		map[string]attr.Value{
-			"provider": types.StringValue("aws"),
-			"region":   types.StringValue("us-east-1"),
+			"provider": types.StringValue(cluster.CloudProvider),
+			"region":   types.StringValue(cluster.Region),
 		},
 	)
 	if diagnostics != nil {

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -337,6 +338,19 @@ func (r *virtualClusterResource) Read(ctx context.Context, req resource.ReadRequ
 	state.AgentPoolName = types.StringValue(cluster.AgentPoolName)
 	state.CreatedAt = types.StringValue(cluster.CreatedAt)
 	state.Default = types.BoolValue(cluster.Name == "vcn_default")
+
+	cloudValue, diagnostics := types.ObjectValue(
+		virtualClusterCloudModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"provider": types.StringValue("aws"),
+			"region":   types.StringValue("us-east-1"),
+		},
+	)
+	if diagnostics != nil {
+		resp.Diagnostics.Append(diagnostics...)
+		return
+	}
+	state.Cloud = cloudValue
 
 	// Set state
 	diags = resp.State.Set(ctx, &state)

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -103,5 +103,7 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.auto_create_topic", fmt.Sprintf("%t", autoTopic)),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_num_partitions", fmt.Sprintf("%d", numParts)),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "configuration.default_retention_millis", fmt.Sprintf("%d", 86400000)),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "cloud.provider", "aws"),
+		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "cloud.region", "us-east-1"),
 	)
 }


### PR DESCRIPTION
Fixes https://github.com/warpstreamlabs/terraform-provider-warpstream/issues/61

The virtualClusterResource's `Read` method is missing the `Cloud` property when refreshing state.

Currently there isn't a framework to unit test the `Read` method for `virtualClusterResource` as we would need to mock the `/describe_virtual_cluster"` endpoint.