### PR TITLE
Assert vcs data source with custom check function

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ make testacc
 
 Creating a new provider release is as simple as pushing a corresponding git tag.
 The tag name must follow the Semantic Versioning standard.
+
+Tagging a commit can be done from the git CLI or the GitHub UI. One benefit of
+using the GitHub UI is that GitHub supports release notes.
+
+To publish via GitHub, Go to this repository's [Releases Page][] to view our
+release history, then click "Draft a new release".  Publishing a release will
+automatically kick off a Goreleaser workflow in GitHub actions that will
+publish to the Hashicorp registry. Once that workflow has completed, visit [our
+listing][] in the registry to confirm that the new version is availalbe.
+
+To publish via git
+
 ```shell
 git tag v<MAJOR>.<MINOR>.<PATCH>
 git push origin v<MAJOR>.<MINOR>.<PATCH>
@@ -72,4 +84,7 @@ git push origin v<MAJOR>.<MINOR>.<PATCH>
 
 See [Publishing Providers][] for details.
 
+[Releases Page]: https://github.com/warpstreamlabs/terraform-provider-warpstream/releases/
+[our listing]: https://registry.terraform.io/providers/warpstreamlabs/warpstream/latest
 [Publishing Providers]: https://developer.hashicorp.com/terraform/registry/providers/publishing
+

--- a/internal/provider/virtual_clusters_data_source_test.go
+++ b/internal/provider/virtual_clusters_data_source_test.go
@@ -1,33 +1,25 @@
 package provider
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-/*
-TestAccVirtualClustersDataSource checks for expected attributes on the virtual_clusters data source.
-
-TODO: Some checks we should run, e.g. on the number of virtual clusters, fail in CI. Probably because of
-test parallelism. The virtual cluster resource test suite creates virtual clusters so this suite can't
-expect a fixed number of virtual clusters.
-
-Work around this by writing custom check functions for the virtual_cluster data source.
-https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests/teststep#custom-check-functions
-*/
+// TestAccVirtualClustersDataSource checks for expected attributes on the virtual_clusters data source.
 func TestAccVirtualClustersDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVirtualClustersDataSource_default(),
-				Check:  testAccVCsDataSourceCheckServerless("tivo_serverless"),
-			},
-			{
-				Config: testAccVirtualClustersDataSource_default(),
-				Check:  testAccVCsDataSourceCheckBYOC("wtf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckVirtualClustersState(),
+				),
 			},
 		},
 	})
@@ -39,27 +31,155 @@ data "warpstream_virtual_clusters" "test" {
 }`
 }
 
-func testAccVCsDataSourceCheckServerless(serverlessVCName string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		// TODO: See TestAccVirtualClustersDataSource comment.
-		// resource.TestCheckResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.#", "5"),
-		resource.TestCheckResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.0.name", "vcn_"+serverlessVCName),
-		utils.TestCheckResourceAttrStartsWith("data.warpstream_virtual_clusters.test", "virtual_clusters.0.agent_pool_name", "apn_"+serverlessVCName),
-		resource.TestCheckResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.0.type", "serverless"),
-		// No agent keys in serverless clusters.
-		resource.TestCheckNoResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.0.agent_keys"),
-	)
+/*
+testCheckVirtualClustersState is a helper to check the state of the virtual clusters data source.
+We can't expect a fixed list of virtual clusters in CI since we run tests in parallel and the virtual cluster
+resource test suite creates virtual clusters.
+There must be a better way to deserialize the data source's attributes but I couldn't figure it out from the docs.
+https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests/teststep#custom-check-functions
+*/
+func testCheckVirtualClustersState() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceName := "data.warpstream_virtual_clusters.test"
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Could not find %s resource in root module", resourceName)
+		}
+
+		vcs, err := attributesMapToVCStatesSlice(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		err = assertBYOCVC(vcs, "wtf")
+		if err != nil {
+			return err
+		}
+
+		err = assertServerlessVC(vcs, "tivo_serverless")
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
-func testAccVCsDataSourceCheckBYOC(byocVCName string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		// TODO: See TestAccVirtualClustersDataSource comment.
-		// resource.TestCheckResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.#", "5"),
-		resource.TestCheckResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.2.name", "vcn_"+byocVCName),
-		utils.TestCheckResourceAttrStartsWith("data.warpstream_virtual_clusters.test", "virtual_clusters.2.agent_pool_name", "apn_"+byocVCName),
-		resource.TestCheckResourceAttr("data.warpstream_virtual_clusters.test", "virtual_clusters.2.type", "byoc"),
-		resource.TestCheckResourceAttr(
-			"data.warpstream_virtual_clusters.test", "virtual_clusters.2.agent_keys.0.name", "akn_virtual_cluster_wtf_af207e45b4e8",
-		),
-	)
+func assertBYOCVC(vcs []map[string]string, name string) error {
+	vc, err := getVCWithName(vcs, "vcn_"+name)
+	if err != nil {
+		return err
+	}
+
+	if vc["type"] != "byoc" {
+		return fmt.Errorf("Expected BYOC virtual cluster, got %s", vc["type"])
+	}
+
+	if !strings.HasPrefix(vc["agent_pool_name"], "apn_"+name) {
+		return fmt.Errorf("Expected agent pool name to start with 'apn_%s', got %s", name, vc["agent_pool_name"])
+	}
+
+	agentKeysCountAttr, ok := vc["agent_keys.#"]
+	if !ok {
+		return errors.New("Expected BYOC cluter to have agent keys")
+	}
+	if agentKeysCountAttr != "1" {
+		return fmt.Errorf("Expected 1 agent key, got %s", agentKeysCountAttr)
+	}
+	agentKeyNameAttr, ok := vc["agent_keys.0.name"]
+	if !ok {
+		return errors.New("Expected agent key name")
+	}
+	if agentKeyNameAttr != "akn_virtual_cluster_wtf_af207e45b4e8" {
+		return fmt.Errorf("Expected agent key name to be 'akn_virtual_cluster_wtf_af207e45b4e8', got %s", agentKeyNameAttr)
+	}
+	agentKeysVCIDAttr, ok := vc["agent_keys.0.virtual_cluster_id"]
+	if !ok {
+		return errors.New("Expected agent key virtual cluster ID")
+	}
+	if agentKeysVCIDAttr != "vci_daf191a9_47fa_4215_aa49_2e74c5ba78d9" {
+		return fmt.Errorf("Expected agent key virtual cluster ID to be 'vci_daf191a9_47fa_4215_aa49_2e74c5ba78d9', got %s", agentKeysVCIDAttr)
+	}
+
+	return nil
+}
+
+func assertServerlessVC(vcs []map[string]string, name string) error {
+	vc, err := getVCWithName(vcs, "vcn_"+name)
+	if err != nil {
+		return err
+	}
+
+	if vc["type"] != "serverless" {
+		return fmt.Errorf("Expected serverless virtual cluster, got %s", vc["type"])
+	}
+
+	if _, ok := vc["agent_keys"]; ok {
+		return fmt.Errorf("Serverless virtual cluster should not have agent keys")
+	}
+
+	if !strings.HasPrefix(vc["agent_pool_name"], "apn_"+name) {
+		return fmt.Errorf(
+			"Expected agent pool name to start with 'apn_%s', got %s",
+			name,
+			vc["agent_pool_name"],
+		)
+	}
+
+	return nil
+}
+
+func getVCWithName(vcs []map[string]string, name string) (map[string]string, error) {
+	for _, vc := range vcs {
+		if vc["name"] == name {
+			return vc, nil
+		}
+	}
+	return nil, fmt.Errorf("No virtual cluster with name %s found", name)
+}
+
+/*
+attributesMapToVCStatesSlice is a helper to convert the virtual_clusters data source attributes to a slice of
+virtual cluster states. TF probably has a better way to do this but I couldn't figure it out from the docs.
+
+	In: map[string]string{
+		"virtual_clusters.3.agent_pool_name": "apn_default_80hc",
+		"virtual_clusters.1.name": "vcn_streambased",
+	}
+
+	Out: []map[string]string{{"agent_pool_name": "apn_default_80hc"}, {"name": "vcn_streambased"}}
+*/
+func attributesMapToVCStatesSlice(attrsSlice map[string]string) ([]map[string]string, error) {
+	vcsMap := make(map[byte]map[string]string)
+	for k, v := range attrsSlice { // k = "virtual_clusters.1.name", v = "vcn_streambased"
+		if k == "%" { // "%" added by TF to represent a map's length.
+			continue
+		}
+
+		suffixedAttribute, found := strings.CutPrefix(k, "virtual_clusters.")
+		if !found {
+			return nil, fmt.Errorf("Unexpected attribute: %s", k)
+		}
+
+		if suffixedAttribute == "#" { // "#" added by TF to represent a list's length.
+			continue
+		}
+
+		vcKey := suffixedAttribute[0]       // Some byte representing "0" to however many VCs we have.
+		vcAttrName := suffixedAttribute[2:] // E.g. "name"
+		if _, ok := vcsMap[vcKey]; !ok {
+			vcsMap[vcKey] = map[string]string{
+				vcAttrName: v,
+			}
+		} else {
+			vcsMap[vcKey][vcAttrName] = v
+		}
+	}
+
+	vcs := make([]map[string]string, 0, len(vcsMap))
+	for _, vc := range vcsMap {
+		vcs = append(vcs, vc)
+	}
+
+	return vcs, nil
 }


### PR DESCRIPTION
A bit of diy to get around the fact that we run tests in parallel. We can't make assertions that depend on vcs being in a determined state.

Also
- Refactor virtual cluster data source test
- Add instructions to readme for releasing our provider via github