### PR TITLE
Remove Serverless Support

### DIFF
--- a/docs/data-sources/virtual_cluster.md
+++ b/docs/data-sources/virtual_cluster.md
@@ -40,10 +40,10 @@ output "vc_default_id" {
 
 ### Read-Only
 
-- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster. Null for Serverless clusters. (see [below for nested schema](#nestedatt--agent_keys))
+- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster. (see [below for nested schema](#nestedatt--agent_keys))
 - `agent_pool_id` (String)
 - `agent_pool_name` (String)
-- `bootstrap_url` (String) Bootstrap URL to connect to the Virtual Cluster. Null for Serverless clusters.
+- `bootstrap_url` (String) Bootstrap URL to connect to the Virtual Cluster.
 - `cloud` (Attributes) (see [below for nested schema](#nestedatt--cloud))
 - `configuration` (Attributes) (see [below for nested schema](#nestedatt--configuration))
 - `created_at` (String)

--- a/docs/data-sources/virtual_clusters.md
+++ b/docs/data-sources/virtual_clusters.md
@@ -24,10 +24,10 @@ description: |-
 
 Read-Only:
 
-- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster. Null for Serverless clusters. (see [below for nested schema](#nestedatt--virtual_clusters--agent_keys))
+- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster. (see [below for nested schema](#nestedatt--virtual_clusters--agent_keys))
 - `agent_pool_id` (String)
 - `agent_pool_name` (String)
-- `bootstrap_url` (String) Bootstrap URL to connect to the Virtual Cluster. Null for Serverless clusters.
+- `bootstrap_url` (String) Bootstrap URL to connect to the Virtual Cluster.
 - `created_at` (String)
 - `id` (String)
 - `name` (String)

--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -17,11 +17,6 @@ resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test"
 }
 
-resource "warpstream_virtual_cluster" "test_serverless" {
-  name = "vcn_test_serverless"
-  type = "serverless"
-}
-
 resource "warpstream_virtual_cluster" "test_with_acls" {
   name = "vcn_test_acls"
   configuration = {
@@ -59,14 +54,14 @@ resource "warpstream_virtual_cluster" "test_cloud_region" {
 
 - `cloud` (Attributes) Virtual Cluster Cloud Location. (see [below for nested schema](#nestedatt--cloud))
 - `configuration` (Attributes) Virtual Cluster Configuration. (see [below for nested schema](#nestedatt--configuration))
-- `type` (String) Virtual Cluster Type. Valid virtual cluster types are `byoc` (default) and `serverless`. See [Serverless Clusters](https://docs.warpstream.com/warpstream/reference/serverless-clusters).
+- `type` (String) Virtual Cluster Type. Currently, the only valid virtual cluster types is `byoc` (default).
 
 ### Read-Only
 
-- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster. Null for Serverless clusters. (see [below for nested schema](#nestedatt--agent_keys))
+- `agent_keys` (Attributes List) List of keys to authenticate an agent with this cluster.. (see [below for nested schema](#nestedatt--agent_keys))
 - `agent_pool_id` (String) Agent Pool ID.
 - `agent_pool_name` (String) Agent Pool Name.
-- `bootstrap_url` (String) Bootstrap URL to connect to the Virtual Cluster. Null for Serverless clusters.
+- `bootstrap_url` (String) Bootstrap URL to connect to the Virtual Cluster.
 - `created_at` (String) Virtual Cluster Creation Timestamp.
 - `default` (Boolean)
 - `id` (String) Virtual Cluster ID.

--- a/examples/byoc-with-topics/main.tf
+++ b/examples/byoc-with-topics/main.tf
@@ -42,7 +42,7 @@ resource "warpstream_agent_key" "terraform_cluster_key" {
 
 provider "kafka" {
   # WarpStream's serverless endpoint can be used to administer metadata
-  # for BYOC clusters *and* Serverless clusters.
+  # for BYOC clusters.
   bootstrap_servers = ["serverless.warpstream.com:9092"]
   tls_enabled       = true
   sasl_mechanism    = "plain"

--- a/examples/resources/warpstream_virtual_cluster/resource.tf
+++ b/examples/resources/warpstream_virtual_cluster/resource.tf
@@ -2,11 +2,6 @@ resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test"
 }
 
-resource "warpstream_virtual_cluster" "test_serverless" {
-  name = "vcn_test_serverless"
-  type = "serverless"
-}
-
 resource "warpstream_virtual_cluster" "test_with_acls" {
   name = "vcn_test_acls"
   configuration = {

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -1,8 +1,10 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -18,13 +20,13 @@ func TestPipelineResource(t *testing.T) {
 	})
 }
 func testPipeline() string {
-	return providerConfig + `
-data "warpstream_virtual_cluster" "default" {
-  default = true
-}
-
+	virtualClusterResource := fmt.Sprintf(`
+resource "warpstream_virtual_cluster" "test" {
+	name = "vcn_test_acc_%s"
+}`, acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
+	return providerConfig + virtualClusterResource + `
 resource "warpstream_pipeline" "test_pipeline" {
-  virtual_cluster_id = data.warpstream_virtual_cluster.default.id
+  virtual_cluster_id = data.warpstream_virtual_cluster.test.id
   name               = "test_pipeline"
   state              = "running"
   configuration_yaml = <<EOT

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -26,7 +26,7 @@ resource "warpstream_virtual_cluster" "test" {
 }`, acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	return providerConfig + virtualClusterResource + `
 resource "warpstream_pipeline" "test_pipeline" {
-  virtual_cluster_id = data.warpstream_virtual_cluster.test.id
+  virtual_cluster_id = warpstream_virtual_cluster.test.id
   name               = "test_pipeline"
   state              = "running"
   configuration_yaml = <<EOT

--- a/internal/provider/virtual_cluster.go
+++ b/internal/provider/virtual_cluster.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	virtualClusterTypeBYOC       = "byoc"
-	virtualClusterTypeServerless = "serverless"
+	virtualClusterTypeBYOC = "byoc"
 )
 
 // virtualClusterModel maps virtual cluster schema data.

--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -71,7 +71,7 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 				Computed: true,
 			},
 			"agent_keys": schema.ListNestedAttribute{
-				Description:  "List of keys to authenticate an agent with this cluster. Null for Serverless clusters.",
+				Description:  "List of keys to authenticate an agent with this cluster.",
 				Computed:     true,
 				NestedObject: agentKeyDataSourceSchema,
 			},
@@ -116,7 +116,7 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 				Computed: true,
 			},
 			"bootstrap_url": schema.StringAttribute{
-				Description: "Bootstrap URL to connect to the Virtual Cluster. Null for Serverless clusters.",
+				Description: "Bootstrap URL to connect to the Virtual Cluster.",
 				Computed:    true,
 			},
 		},

--- a/internal/provider/virtual_cluster_data_source_test.go
+++ b/internal/provider/virtual_cluster_data_source_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,10 +15,6 @@ func TestAccVirtualClusterDataSource(t *testing.T) {
 				Config: testAccVirtualClusterDataSource_default(),
 				Check:  testAccVCDataSourceCheck_byoc("default"),
 			},
-			{
-				Config: testAccVirtualClusterDataSource_serverless("vcn_tivo_serverless"),
-				Check:  testAccVCDataSourceCheck_serverless("tivo_serverless"),
-			},
 		},
 	})
 }
@@ -29,13 +24,6 @@ func testAccVirtualClusterDataSource_default() string {
 data "warpstream_virtual_cluster" "test" {
   default = true
 }`
-}
-
-func testAccVirtualClusterDataSource_serverless(name string) string {
-	return providerConfig + fmt.Sprintf(`
-data "warpstream_virtual_cluster" "test" {
-  name = "%s"
-}`, name)
 }
 
 func testAccVCDataSourceCheck_byoc(name string) resource.TestCheckFunc {
@@ -50,14 +38,6 @@ func testAccVCDataSourceCheck_byoc(name string) resource.TestCheckFunc {
 			"bootstrap_url",
 			".kafka.discoveryv2.prod-z.us-east-1.warpstream.com:9092",
 		),
-		testAccVCDataSourceCheck(name),
-	)
-}
-
-func testAccVCDataSourceCheck_serverless(name string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttr("data.warpstream_virtual_cluster.test", "type", "serverless"),
-		resource.TestCheckNoResourceAttr("data.warpstream_virtual_cluster.test", "agent_keys"),
 		testAccVCDataSourceCheck(name),
 	)
 }

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -113,7 +113,7 @@ This resource allows you to create, update and delete virtual clusters.
 				Validators: []validator.String{utils.StartsWith("vcn_")},
 			},
 			"type": schema.StringAttribute{
-				Description: "Virtual Cluster Type. Valid virtual cluster types are `byoc` (default) and `serverless`. See [Serverless Clusters](https://docs.warpstream.com/warpstream/reference/serverless-clusters).",
+				Description: "Virtual Cluster Type. Currently, the only valid virtual cluster types is `byoc` (default).",
 				Computed:    true,
 				Optional:    true,
 				Default:     stringdefault.StaticString(virtualClusterTypeBYOC),
@@ -121,11 +121,11 @@ This resource allows you to create, update and delete virtual clusters.
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{virtualClusterTypeBYOC, virtualClusterTypeServerless}...),
+					stringvalidator.OneOf([]string{virtualClusterTypeBYOC}...),
 				},
 			},
 			"agent_keys": schema.ListNestedAttribute{
-				Description:  "List of keys to authenticate an agent with this cluster. Null for Serverless clusters.",
+				Description:  "List of keys to authenticate an agent with this cluster..",
 				Computed:     true,
 				NestedObject: agentKeyResourceSchema,
 			},
@@ -226,7 +226,7 @@ This resource allows you to create, update and delete virtual clusters.
 				},
 			},
 			"bootstrap_url": schema.StringAttribute{
-				Description: "Bootstrap URL to connect to the Virtual Cluster. Null for Serverless clusters.",
+				Description: "Bootstrap URL to connect to the Virtual Cluster.",
 				Computed:    true,
 			},
 		},

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -29,10 +29,6 @@ func TestAccVirtualClusterResource(t *testing.T) {
 				Config: testAccVirtualClusterResource_withConfiguration(true, false, 2),
 				Check:  testAccVirtualClusterResourceCheck_BYOC(true, false, 2),
 			},
-			{
-				Config: testAccVirtualClusterResource_withType("serverless"),
-				Check:  testAccVirtualClusterResourceCheck_Serverless(false, true, 1),
-			},
 		},
 	})
 }
@@ -42,14 +38,6 @@ func testAccVirtualClusterResource() string {
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
 }`, nameSuffix)
-}
-
-func testAccVirtualClusterResource_withType(t string) string {
-	return providerConfig + fmt.Sprintf(`
-resource "warpstream_virtual_cluster" "test" {
-  name = "vcn_test_acc_%s"
-  type = "%s"
-}`, nameSuffix, t)
 }
 
 func testAccVirtualClusterResource_withPartialConfiguration(acls bool) string {
@@ -80,14 +68,6 @@ func testAccVirtualClusterResourceCheck_BYOC(acls bool, autoTopic bool, numParts
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "agent_keys.#", "1"),
 		utils.TestCheckResourceAttrStartsWith("warpstream_virtual_cluster.test", "agent_keys.0.name", "akn_virtual_cluster_test_acc_"),
 		utils.TestCheckResourceAttrEndsWith("warpstream_virtual_cluster.test", "bootstrap_url", ".kafka.discoveryv2.prod-z.us-east-1.warpstream.com:9092"),
-	)
-}
-
-func testAccVirtualClusterResourceCheck_Serverless(acls bool, autoTopic bool, numParts int64) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		testAccVirtualClusterResourceCheck(acls, autoTopic, numParts, "serverless"),
-		resource.TestCheckNoResourceAttr("warpstream_virtual_cluster.test", "agent_keys"),
-		resource.TestCheckNoResourceAttr("warpstream_virtual_cluster.test", "bootstrap_url"),
 	)
 }
 

--- a/internal/provider/virtual_clusters_data_source.go
+++ b/internal/provider/virtual_clusters_data_source.go
@@ -66,7 +66,7 @@ func (d *virtualClustersDataSource) Schema(_ context.Context, _ datasource.Schem
 							Computed: true,
 						},
 						"agent_keys": schema.ListNestedAttribute{
-							Description:  "List of keys to authenticate an agent with this cluster. Null for Serverless clusters.",
+							Description:  "List of keys to authenticate an agent with this cluster.",
 							Computed:     true,
 							NestedObject: agentKeyDataSourceSchema,
 						},
@@ -77,7 +77,7 @@ func (d *virtualClustersDataSource) Schema(_ context.Context, _ datasource.Schem
 							Computed: true,
 						},
 						"bootstrap_url": schema.StringAttribute{
-							Description: "Bootstrap URL to connect to the Virtual Cluster. Null for Serverless clusters.",
+							Description: "Bootstrap URL to connect to the Virtual Cluster.",
 							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{

--- a/internal/provider/virtual_clusters_data_source_test.go
+++ b/internal/provider/virtual_clusters_data_source_test.go
@@ -56,11 +56,6 @@ func testCheckVirtualClustersState() resource.TestCheckFunc {
 			return err
 		}
 
-		err = assertServerlessVC(vcs, "tivo_serverless")
-		if err != nil {
-			return err
-		}
-
 		return nil
 	}
 }
@@ -115,35 +110,6 @@ func assertBYOCVC(vcs []map[string]string, name string) error {
 			expectedBurl,
 			vc["bootstrap_url"],
 		)
-	}
-
-	return nil
-}
-
-func assertServerlessVC(vcs []map[string]string, name string) error {
-	vc, err := getVCWithName(vcs, "vcn_"+name)
-	if err != nil {
-		return err
-	}
-
-	if vc["type"] != "serverless" {
-		return fmt.Errorf("Expected serverless virtual cluster, got %s", vc["type"])
-	}
-
-	if _, ok := vc["agent_keys"]; ok {
-		return fmt.Errorf("Serverless virtual cluster should not have agent keys")
-	}
-
-	if !strings.HasPrefix(vc["agent_pool_name"], "apn_"+name) {
-		return fmt.Errorf(
-			"Expected agent pool name to start with 'apn_%s', got %s",
-			name,
-			vc["agent_pool_name"],
-		)
-	}
-
-	if _, ok := vc["bootstrap_url"]; ok {
-		return fmt.Errorf("Serverless virtual cluster should not have a bootstrap URL field")
 	}
 
 	return nil


### PR DESCRIPTION
no longer support serverless clusters with WarpStream terraform provider. Also fixes a race condition with our `pipeline` test