### PR TITLE
Change nightly test to 1 am EST

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ on:
     paths-ignore:
       - 'README.md'
   schedule:
-    # Run daily at 12am UTC
-    - cron:  '0 0 * * *'
+    # Run daily at 6 am UTC
+    - cron:  '0 6 * * *'
 
 # Testing only needs permissions to read the repository contents.
 permissions:


### PR DESCRIPTION
Currently, the test is 7 pm EST, so it is often lost amongst PR messages. Changing this so that it appears around the same time as WarpStream's nightly test runs