### PR TITLE
Fix Terraform Import Virtual Cluster

### DIFF
--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -346,6 +346,17 @@ func (r *virtualClusterResource) Read(ctx context.Context, req resource.ReadRequ
 		state.BootstrapURL = types.StringValue(*cluster.BootstrapURL)
 	}
 
+	agentKeysState, ok := mapToAgentKeyModels(cluster.AgentKeys, &resp.Diagnostics)
+	if !ok { // Diagnostics handled by helper.
+		return
+	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("agent_keys"), agentKeysState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	cloudValue, diagnostics := types.ObjectValue(
 		virtualClusterCloudModel{}.AttributeTypes(),
 		map[string]attr.Value{
@@ -407,17 +418,6 @@ func (r *virtualClusterResource) Delete(ctx context.Context, req resource.Delete
 func (r *virtualClusterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-
-	// Retrieve cluster info from imported state
-	var data virtualClusterResourceModel
-	diags := resp.State.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Fetch virtual cluster configuration
-	r.readConfiguration(ctx, data.cluster(), &resp.State, &resp.Diagnostics)
 }
 
 func (m virtualClusterResourceModel) cluster() api.VirtualCluster {

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -346,17 +346,6 @@ func (r *virtualClusterResource) Read(ctx context.Context, req resource.ReadRequ
 		state.BootstrapURL = types.StringValue(*cluster.BootstrapURL)
 	}
 
-	agentKeysState, ok := mapToAgentKeyModels(cluster.AgentKeys, &resp.Diagnostics)
-	if !ok { // Diagnostics handled by helper.
-		return
-	}
-
-	diags = resp.State.SetAttribute(ctx, path.Root("agent_keys"), agentKeysState)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	cloudValue, diagnostics := types.ObjectValue(
 		virtualClusterCloudModel{}.AttributeTypes(),
 		map[string]attr.Value{
@@ -378,6 +367,16 @@ func (r *virtualClusterResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	r.readConfiguration(ctx, *cluster, &resp.State, &resp.Diagnostics)
+
+	// agentKeysState, ok := mapToAgentKeyModels(cluster.AgentKeys, &resp.Diagnostics)
+	// if !ok { // Diagnostics handled by helper.
+	// 	return
+	// }
+	// diags = resp.State.SetAttribute(ctx, path.Root("agent_keys"), agentKeysState)
+	// resp.Diagnostics.Append(diags...)
+	// if resp.Diagnostics.HasError() {
+	// 	return
+	// }
 }
 
 // Update updates the resource and sets the updated Terraform state on success.

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -368,15 +368,15 @@ func (r *virtualClusterResource) Read(ctx context.Context, req resource.ReadRequ
 
 	r.readConfiguration(ctx, *cluster, &resp.State, &resp.Diagnostics)
 
-	// agentKeysState, ok := mapToAgentKeyModels(cluster.AgentKeys, &resp.Diagnostics)
-	// if !ok { // Diagnostics handled by helper.
-	// 	return
-	// }
-	// diags = resp.State.SetAttribute(ctx, path.Root("agent_keys"), agentKeysState)
-	// resp.Diagnostics.Append(diags...)
-	// if resp.Diagnostics.HasError() {
-	// 	return
-	// }
+	agentKeysState, ok := mapToAgentKeyModels(cluster.AgentKeys, &resp.Diagnostics)
+	if !ok { // Diagnostics handled by helper.
+		return
+	}
+	diags = resp.State.SetAttribute(ctx, path.Root("agent_keys"), agentKeysState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 // Update updates the resource and sets the updated Terraform state on success.

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -4,21 +4,23 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
 )
 
 func TestAccVirtualClusterResource(t *testing.T) {
+	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVirtualClusterResource_withPartialConfiguration(false),
+				Config: testAccVirtualClusterResource_withPartialConfiguration(false, vcNameSuffix),
 				Check:  testAccVirtualClusterResourceCheck_BYOC(false, true, 1),
 			},
 			{
-				Config: testAccVirtualClusterResource(),
+				Config: testAccVirtualClusterResource(vcNameSuffix),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -26,31 +28,39 @@ func TestAccVirtualClusterResource(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccVirtualClusterResource_withConfiguration(true, false, 2),
+				Config: testAccVirtualClusterResource_withConfiguration(true, false, 2, vcNameSuffix),
 				Check:  testAccVirtualClusterResourceCheck_BYOC(true, false, 2),
 			},
 		},
 	})
 }
 
-func testAccVirtualClusterResource() string {
+func testAccVirtualClusterResource(vcNameSuffix string) string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
-}`, nameSuffix)
+}`, vcNameSuffix)
 }
 
-func testAccVirtualClusterResource_withPartialConfiguration(acls bool) string {
+func testAccVirtualClusterResource_withPartialConfiguration(
+	acls bool,
+	vcNameSuffix string,
+) string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
   configuration = {
     enable_acls = %t
   }
-}`, nameSuffix, acls)
+}`, vcNameSuffix, acls)
 }
 
-func testAccVirtualClusterResource_withConfiguration(acls bool, autoTopic bool, numParts int64) string {
+func testAccVirtualClusterResource_withConfiguration(
+	acls bool,
+	autoTopic bool,
+	numParts int64,
+	vcNameSuffix string,
+) string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
@@ -59,7 +69,7 @@ resource "warpstream_virtual_cluster" "test" {
     default_num_partitions = %d
     auto_create_topic = %t
   }
-}`, nameSuffix, acls, numParts, autoTopic)
+}`, vcNameSuffix, acls, numParts, autoTopic)
 }
 
 func testAccVirtualClusterResourceCheck_BYOC(acls bool, autoTopic bool, numParts int64) resource.TestCheckFunc {
@@ -87,4 +97,22 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "cloud.provider", "aws"),
 		resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "cloud.region", "us-east-1"),
 	)
+}
+
+func TestAccVirtualClusterImport(t *testing.T) {
+	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVirtualClusterResource(vcNameSuffix),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "warpstream_virtual_cluster.test",
+			},
+		},
+		IsUnitTest: true,
+	})
 }


### PR DESCRIPTION
I realized that there is no test for `import`ing a virtual cluster so I added one. Then I realized we forgot to import agent keys:

```
--- FAIL: TestAccVirtualClusterImport (15.29s)
    /Users/brianshih/Desktop/code/terraform-provider-warpstream/internal/provider/virtual_cluster_resource_test.go:106: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"agent_keys.#":                    "1",
        - 	"agent_keys.0.%":                  "5",
        - 	"agent_keys.0.created_at":         "2024-12-09T05:43:07.39084Z",
        - 	"agent_keys.0.id":                 "aki_15bc21fa_9423_4c39_a5ae_8b186fd04ec2",
        - 	"agent_keys.0.key":                "aks_2e8a3d24a4b8e9bcaeffaef7b98aa8b3927c8a2b354887b01ea72fddd21fe084",
        - 	"agent_keys.0.name":               "akn_virtual_cluster_test_acc_v2oyfm_d04200d28c84",
        - 	"agent_keys.0.virtual_cluster_id": "vci_152ca71e_6b30_41d6_93da_26dd13910c5c",
          }
```

I also refactored the import to only import the `ID` since according to the [documentation](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md#importresourcestate),  the best practice is to pass the minimal attributes that `ReadResource` needs then let `ReadResource` do the work. Here is the quote:
> Terraform Core will always pass the returned Import Stub State to the normal ReadResource operation after ImportResourceState returns it, so in practice the provider may populate only the minimal subset of attributes that ReadResource will need to do its work, letting the normal function deal with populating the rest of the data to match what is currently set in the remote system.
 