### PR TITLE
Make sure virtual cluster datasource not start with vci_sr

### DIFF
--- a/internal/provider/utils/validators.go
+++ b/internal/provider/utils/validators.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -13,4 +15,34 @@ func StartsWith(prefix string) validator.String {
 		regexp.MustCompile(fmt.Sprintf("^%s[a-zA-Z0-9_]+$", prefix)),
 		fmt.Sprintf("must start with '%s' and must contain underscores and alphanumeric characters only", prefix),
 	)
+}
+
+// Unfortunately, Golang's regex doesn't support negative lookahead,
+// so we can't do ^(?!prefix).
+type notStartWithValidator struct {
+	prefix string
+}
+
+func (validator notStartWithValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must not start with '%s'", validator.prefix)
+}
+
+func (validator notStartWithValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (v notStartWithValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	if strings.HasPrefix(value, v.prefix) {
+		response.Diagnostics.AddError("invalid prefix", fmt.Sprintf("property must not start with: %s", v.prefix))
+	}
+}
+
+func NotStartWith(prefix string) validator.String {
+	return notStartWithValidator{prefix: prefix}
 }

--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
+	warpstreamtypes "github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/types"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -62,6 +66,10 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 			"id": schema.StringAttribute{
 				Computed: true,
 				Optional: true,
+				Validators: []validator.String{
+					// Cannot read from a schema registry
+					utils.NotStartWith("vci_sr_"),
+				},
 			},
 			"name": schema.StringAttribute{
 				Computed: true,
@@ -69,6 +77,9 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 			},
 			"type": schema.StringAttribute{
 				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{warpstreamtypes.VirtualClusterTypeBYOC}...),
+				},
 			},
 			"agent_keys": schema.ListNestedAttribute{
 				Description:  "List of keys to authenticate an agent with this cluster.",

--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -13,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
-	warpstreamtypes "github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/types"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
 )
 
@@ -74,12 +72,13 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 			"name": schema.StringAttribute{
 				Computed: true,
 				Optional: true,
+				Validators: []validator.String{
+					// Cannot read from a schema registry
+					utils.NotStartWith("vcn_sr_"),
+				},
 			},
 			"type": schema.StringAttribute{
 				Computed: true,
-				Validators: []validator.String{
-					stringvalidator.OneOf([]string{warpstreamtypes.VirtualClusterTypeBYOC}...),
-				},
 			},
 			"agent_keys": schema.ListNestedAttribute{
 				Description:  "List of keys to authenticate an agent with this cluster.",

--- a/internal/provider/virtual_cluster_data_source_test.go
+++ b/internal/provider/virtual_cluster_data_source_test.go
@@ -88,7 +88,7 @@ func testAccVCDataSourceCheck(vc *api.VirtualCluster) resource.TestCheckFunc {
 	)
 }
 
-// Verify that the virtual cluster data source doesn't work with schema registry clusters
+// Verify that the virtual cluster data source doesn't work with schema registry clusters.
 func TestAccVirtualClusterDatasource_SchemaRegistryNotWork(t *testing.T) {
 	client, err := api.NewClientDefault()
 	require.NoError(t, err)

--- a/internal/provider/virtual_cluster_data_source_test.go
+++ b/internal/provider/virtual_cluster_data_source_test.go
@@ -52,6 +52,13 @@ data "warpstream_virtual_cluster" "test" {
 }`, id)
 }
 
+func testAccVirtualClusterDataSourceWithName(name string) string {
+	return providerConfig + fmt.Sprintf(`
+data "warpstream_virtual_cluster" "test" {
+  name = "%s"
+}`, name)
+}
+
 func testAccVCDataSourceCheck_byoc(vc *api.VirtualCluster) resource.TestCheckFunc {
 	agentKeyName := ""
 	if vc.AgentKeys != nil {
@@ -115,8 +122,11 @@ func TestAccVirtualClusterDatasource_SchemaRegistryNotWork(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccVirtualClusterDataSourceWithID(vc.ID),
-				Check:       testAccVCDataSourceCheck_byoc(vc),
 				ExpectError: regexp.MustCompile("must not start with: vci_sr_"),
+			},
+			{
+				Config:      testAccVirtualClusterDataSourceWithName(vc.Name),
+				ExpectError: regexp.MustCompile("must not start with: vcn_sr_"),
 			},
 		},
 	})


### PR DESCRIPTION
Since we will have a schema registry datasource, this PR makes sure that users can't use virtual cluster datasource for a schema registry cluster.