### PR TITLE
handle resources not found except topics

### DIFF
--- a/internal/provider/agent_key_resource_test.go
+++ b/internal/provider/agent_key_resource_test.go
@@ -2,10 +2,53 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
 )
+
+func TestAccAgentKeyResourceDeletePlan(t *testing.T) {
+	name := "akn_test_agent_key" + nameSuffix
+	vcID := "vci_test_virtual_cluster_id"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentKeyResource(name, vcID),
+				Check:  testAccAgentKeyResourceCheck(name, vcID),
+			},
+			{
+				PreConfig: func() {
+					token := os.Getenv("WARPSTREAM_API_KEY")
+					client, err := api.NewClient("", &token)
+					require.NoError(t, err)
+
+					apiKeys, err := client.GetAPIKeys()
+					require.NoError(t, err)
+
+					var apiKeyID *string
+					for _, apiKey := range apiKeys {
+						if apiKey.Name == name {
+							apiKeyID = &apiKey.ID
+							break
+						}
+					}
+					require.NotNil(t, apiKeyID)
+
+					err = client.DeleteAPIKey(*apiKeyID)
+					require.NoError(t, err)
+				},
+				Config:             testAccAgentKeyResource(name, vcID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
 func TestAccAgentKeyResource(t *testing.T) {
 	name := "akn_test_agent_key" + nameSuffix

--- a/internal/provider/agent_key_resource_test.go
+++ b/internal/provider/agent_key_resource_test.go
@@ -30,16 +30,16 @@ func TestAccAgentKeyResourceDeletePlan(t *testing.T) {
 					apiKeys, err := client.GetAPIKeys()
 					require.NoError(t, err)
 
-					var apiKeyID *string
+					var apiKeyID string
 					for _, apiKey := range apiKeys {
 						if apiKey.Name == name {
-							apiKeyID = &apiKey.ID
+							apiKeyID = apiKey.ID
 							break
 						}
 					}
-					require.NotNil(t, apiKeyID)
+					require.NotEmpty(t, apiKeyID)
 
-					err = client.DeleteAPIKey(*apiKeyID)
+					err = client.DeleteAPIKey(apiKeyID)
 					require.NoError(t, err)
 				},
 				Config:             testAccAgentKeyResource(name, vcID),

--- a/internal/provider/api/api_key.go
+++ b/internal/provider/api/api_key.go
@@ -142,5 +142,5 @@ func (c *Client) GetAPIKey(apiKeyID string) (*APIKey, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("API key with ID %s not found", apiKeyID)
+	return nil, ErrNotFound
 }

--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 )
+
+var ErrNotFound = errors.New("Resource Not Found")
 
 // HostURL - Default Warpstream URL.
 const HostURL string = "https://api.prod.us-east-1.warpstream.com/api/v1"
@@ -79,6 +82,10 @@ func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error)
 		return nil, err
 	}
 	log.Printf("%q\n", body)
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status: %d, body: %s", res.StatusCode, body)

--- a/internal/provider/application_key_resource_test.go
+++ b/internal/provider/application_key_resource_test.go
@@ -2,10 +2,52 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
 )
+
+func TestAccApplicationKeyResourceDeletePLan(t *testing.T) {
+	name := "akn_test_application_key" + nameSuffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationKeyResource(name),
+				Check:  testAccApplicationKeyResourceCheck(name),
+			},
+			{
+				PreConfig: func() {
+					token := os.Getenv("WARPSTREAM_API_KEY")
+					client, err := api.NewClient("", &token)
+					require.NoError(t, err)
+
+					apiKeys, err := client.GetAPIKeys()
+					require.NoError(t, err)
+
+					var apiKeyID *string
+					for _, apiKey := range apiKeys {
+						if apiKey.Name == name {
+							apiKeyID = &apiKey.ID
+							break
+						}
+					}
+					require.NotNil(t, apiKeyID)
+
+					err = client.DeleteAPIKey(*apiKeyID)
+					require.NoError(t, err)
+				},
+				Config:             testAccApplicationKeyResource(name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
 func TestAccApplicationKeyResource(t *testing.T) {
 	name := "akn_test_application_key" + nameSuffix

--- a/internal/provider/application_key_resource_test.go
+++ b/internal/provider/application_key_resource_test.go
@@ -29,16 +29,16 @@ func TestAccApplicationKeyResourceDeletePLan(t *testing.T) {
 					apiKeys, err := client.GetAPIKeys()
 					require.NoError(t, err)
 
-					var apiKeyID *string
+					var apiKeyID string
 					for _, apiKey := range apiKeys {
 						if apiKey.Name == name {
-							apiKeyID = &apiKey.ID
+							apiKeyID = apiKey.ID
 							break
 						}
 					}
-					require.NotNil(t, apiKeyID)
+					require.NotEmpty(t, apiKeyID)
 
-					err = client.DeleteAPIKey(*apiKeyID)
+					err = client.DeleteAPIKey(apiKeyID)
 					require.NoError(t, err)
 				},
 				Config:             testAccApplicationKeyResource(name),

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -231,6 +232,11 @@ func (r *pipelineResource) Read(ctx context.Context, req resource.ReadRequest, r
 		PipelineID:       state.ID.ValueString(),
 	})
 	if err != nil {
+		if errors.Is(err, api.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Reading Pipeline",
 			fmt.Sprintf("Unable to fetch details for pipeline '%s'. Please check the pipeline ID and ensure it exists. Error details: %s", state.ID.ValueString(), err.Error()),
@@ -316,6 +322,10 @@ func (r *pipelineResource) Delete(ctx context.Context, req resource.DeleteReques
 		PipelineID:       state.ID.ValueString(),
 	})
 	if err != nil {
+		if errors.Is(err, api.ErrNotFound) {
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Deleting Pipeline",
 			fmt.Sprintf("Unable to delete pipeline '%s'. Please check your permissions and ensure there are no dependencies on this pipeline. Error details: %s", state.ID.ValueString(), err.Error()),

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -72,14 +72,14 @@ func TestBentoPipelineResourceDeletePlan(t *testing.T) {
 					vcs, err := client.GetVirtualClusters()
 					require.NoError(t, err)
 
-					var virtualCluster *api.VirtualCluster
+					var virtualCluster api.VirtualCluster
 					for _, vc := range vcs {
 						if vc.Name == fmt.Sprintf("vcn_test_acc_%s", vcNameSuffix) {
-							virtualCluster = &vc
+							virtualCluster = vc
 							break
 						}
 					}
-					require.NotNil(t, virtualCluster)
+					require.NotEmpty(t, virtualCluster.ID)
 
 					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
 					require.NoError(t, err)

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -32,14 +32,14 @@ func TestBentoPipelineResourceDeletePlan(t *testing.T) {
 					vcs, err := client.GetVirtualClusters()
 					require.NoError(t, err)
 
-					var virtualCluster *api.VirtualCluster
+					var virtualCluster api.VirtualCluster
 					for _, vc := range vcs {
 						if vc.Name == fmt.Sprintf("vcn_test_acc_%s", vcNameSuffix) {
-							virtualCluster = &vc
+							virtualCluster = vc
 							break
 						}
 					}
-					require.NotNil(t, virtualCluster)
+					require.NotEmpty(t, virtualCluster.ID)
 
 					pipelineListResp, err := client.ListPipelines(context.TODO(), api.HTTPListPipelinesRequest{
 						VirtualClusterID: virtualCluster.ID,

--- a/internal/provider/schema_registry_resource_test.go
+++ b/internal/provider/schema_registry_resource_test.go
@@ -38,14 +38,14 @@ func TestAccSchemaRegistryResourceDeletePlan(t *testing.T) {
 					vcs, err := client.GetVirtualClusters()
 					require.NoError(t, err)
 
-					var virtualCluster *api.VirtualCluster
+					var virtualCluster api.VirtualCluster
 					for _, vc := range vcs {
 						if vc.Name == fmt.Sprintf("vcn_sr_test_%s", vcNameSuffix) {
-							virtualCluster = &vc
+							virtualCluster = vc
 							break
 						}
 					}
-					require.NotNil(t, virtualCluster)
+					require.NotEmpty(t, virtualCluster.ID)
 
 					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
 					require.NoError(t, err)

--- a/internal/provider/schema_registry_resource_test.go
+++ b/internal/provider/schema_registry_resource_test.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
 )
 
@@ -14,6 +17,45 @@ func testSchemaRegistryResource(nameSuffix string) string {
 resource "warpstream_schema_registry" "test" {
   name = "vcn_sr_test_%s"
 }`, nameSuffix)
+}
+
+func TestAccSchemaRegistryResourceDeletePlan(t *testing.T) {
+	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	resourceName := "warpstream_schema_registry.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSchemaRegistryResource(vcNameSuffix),
+				Check:  testCheckSchemaRegistry(resourceName),
+			},
+			{
+				PreConfig: func() {
+					token := os.Getenv("WARPSTREAM_API_KEY")
+					client, err := api.NewClient("", &token)
+					require.NoError(t, err)
+
+					vcs, err := client.GetVirtualClusters()
+					require.NoError(t, err)
+
+					var virtualCluster *api.VirtualCluster
+					for _, vc := range vcs {
+						if vc.Name == fmt.Sprintf("vcn_sr_test_%s", vcNameSuffix) {
+							virtualCluster = &vc
+							break
+						}
+					}
+					require.NotNil(t, virtualCluster)
+
+					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
+					require.NoError(t, err)
+				},
+				Config:             testSchemaRegistryResource(vcNameSuffix),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
 }
 
 func TestAccSchemaRegistryResource(t *testing.T) {

--- a/internal/provider/topic_resource_test.go
+++ b/internal/provider/topic_resource_test.go
@@ -12,6 +12,68 @@ import (
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
 )
 
+// TODO: this currently doesn't work, the describe topic api returns a 500 instead of 404
+// func TestAccTopicResourceNotExists(t *testing.T) {
+
+// 	virtualClusterName := fmt.Sprintf("vcn_%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
+
+// 	resource.Test(t, resource.TestCase{
+// 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: providerConfig + fmt.Sprintf(`
+// resource "warpstream_virtual_cluster" "default" {
+// 	name = "%s"
+// }
+
+// resource "warpstream_topic" "topic" {
+//   topic_name         = "test"
+//   partition_count    = 1
+//   virtual_cluster_id = warpstream_virtual_cluster.default.id
+
+// }
+// 				`, virtualClusterName),
+// 				Check: resource.ComposeAggregateTestCheckFunc(
+// 					utils.TestCheckResourceAttrStartsWith("warpstream_topic.topic", "virtual_cluster_id", "vci_"),
+// 				),
+// 				ConfigStateChecks: []statecheck.StateCheck{
+// 					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("topic_name"), knownvalue.StringExact("test")),
+// 					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("partition_count"), knownvalue.Int64Exact(1)),
+// 					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config"), knownvalue.ListSizeExact(0)),
+// 				},
+// 			},
+// 			{
+// 				PreConfig: func() {
+// 					token := os.Getenv("WARPSTREAM_API_KEY")
+// 					client, _ := api.NewClient("", &token)
+// 					// TODO: error
+
+// 					vcs, _ := client.GetVirtualClusters()
+// 					// TODO: err
+
+// 					var virtualCluster *api.VirtualCluster
+// 					for _, vc := range vcs {
+// 						fmt.Println(vc.Name)
+// 						if vc.Name == virtualClusterName {
+// 							fmt.Println("found vc")
+// 							virtualCluster = &vc
+// 							break
+// 						}
+// 					}
+
+// 					if virtualCluster == nil {
+// 						panic("nil virtual cluster")
+// 					}
+
+// 					_ = client.DeleteTopic(virtualCluster.ID, "test")
+// 					// TODO: err
+// 				},
+// 				RefreshState: true,
+// 			},
+// 		},
+// 	})
+// }
+
 func TestAccTopicResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/virtual_cluster_credentials_resource_test.go
+++ b/internal/provider/virtual_cluster_credentials_resource_test.go
@@ -44,16 +44,16 @@ func TestAccVirtualClusterCredentialsResourceDeletePlan(t *testing.T) {
 					credentials, err := client.GetCredentials(*virtualCluster)
 					require.NoError(t, err)
 
-					var vcCredentialID *string
+					var vcCredentialID string
 					for cID, credential := range credentials {
 						if credential.Name == fmt.Sprintf("ccn_test_%s", nameSuffix) {
-							vcCredentialID = &cID
+							vcCredentialID = cID
 							break
 						}
 					}
-					require.NotNil(t, vcCredentialID)
+					require.NotEmpty(t, vcCredentialID)
 
-					err = client.DeleteCredentials(*vcCredentialID, *virtualCluster)
+					err = client.DeleteCredentials(vcCredentialID, *virtualCluster)
 					require.NoError(t, err)
 				},
 				Config:             testAccVirtualClusterCredentialsResource_withSuperuser(true),
@@ -75,14 +75,14 @@ func TestAccVirtualClusterCredentialsResourceDeletePlan(t *testing.T) {
 					vcs, err := client.GetVirtualClusters()
 					require.NoError(t, err)
 
-					var virtualCluster *api.VirtualCluster
+					var virtualCluster api.VirtualCluster
 					for _, vc := range vcs {
 						if vc.Name == fmt.Sprintf("vcn_%s", nameSuffix) {
-							virtualCluster = &vc
+							virtualCluster = vc
 							break
 						}
 					}
-					require.NotNil(t, virtualCluster)
+					require.NotEmpty(t, virtualCluster.ID)
 
 					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
 					require.NoError(t, err)

--- a/internal/provider/virtual_cluster_credentials_resource_test.go
+++ b/internal/provider/virtual_cluster_credentials_resource_test.go
@@ -32,16 +32,16 @@ func TestAccVirtualClusterCredentialsResourceDeletePlan(t *testing.T) {
 					vcs, err := client.GetVirtualClusters()
 					require.NoError(t, err)
 
-					var virtualCluster *api.VirtualCluster
+					var virtualCluster api.VirtualCluster
 					for _, vc := range vcs {
 						if vc.Name == fmt.Sprintf("vcn_%s", nameSuffix) {
-							virtualCluster = &vc
+							virtualCluster = vc
 							break
 						}
 					}
-					require.NotNil(t, virtualCluster)
+					require.NotEmpty(t, virtualCluster.ID)
 
-					credentials, err := client.GetCredentials(*virtualCluster)
+					credentials, err := client.GetCredentials(virtualCluster)
 					require.NoError(t, err)
 
 					var vcCredentialID string
@@ -53,7 +53,7 @@ func TestAccVirtualClusterCredentialsResourceDeletePlan(t *testing.T) {
 					}
 					require.NotEmpty(t, vcCredentialID)
 
-					err = client.DeleteCredentials(vcCredentialID, *virtualCluster)
+					err = client.DeleteCredentials(vcCredentialID, virtualCluster)
 					require.NoError(t, err)
 				},
 				Config:             testAccVirtualClusterCredentialsResource_withSuperuser(true),

--- a/internal/provider/virtual_cluster_credentials_resource_test.go
+++ b/internal/provider/virtual_cluster_credentials_resource_test.go
@@ -2,13 +2,98 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
 )
+
+func TestAccVirtualClusterCredentialsResourceDeletePlan(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create crednetial
+			{
+				Config: testAccVirtualClusterCredentialsResource_withSuperuser(true),
+				Check:  testAccVirtualClusterCredentialsResourceCheck(true),
+			},
+			// Pre delete credential and try planning
+			{
+				PreConfig: func() {
+					token := os.Getenv("WARPSTREAM_API_KEY")
+					client, err := api.NewClient("", &token)
+					require.NoError(t, err)
+
+					vcs, err := client.GetVirtualClusters()
+					require.NoError(t, err)
+
+					var virtualCluster *api.VirtualCluster
+					for _, vc := range vcs {
+						if vc.Name == fmt.Sprintf("vcn_%s", nameSuffix) {
+							virtualCluster = &vc
+							break
+						}
+					}
+					require.NotNil(t, virtualCluster)
+
+					credentials, err := client.GetCredentials(*virtualCluster)
+					require.NoError(t, err)
+
+					var vcCredentialID *string
+					for cID, credential := range credentials {
+						if credential.Name == fmt.Sprintf("ccn_test_%s", nameSuffix) {
+							vcCredentialID = &cID
+							break
+						}
+					}
+					require.NotNil(t, vcCredentialID)
+
+					err = client.DeleteCredentials(*vcCredentialID, *virtualCluster)
+					require.NoError(t, err)
+				},
+				Config:             testAccVirtualClusterCredentialsResource_withSuperuser(true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Create credential
+			{
+				Config: testAccVirtualClusterCredentialsResource_withSuperuser(true),
+				Check:  testAccVirtualClusterCredentialsResourceCheck(true),
+			},
+			// Delete virtual cluster and try planning
+			{
+				PreConfig: func() {
+					token := os.Getenv("WARPSTREAM_API_KEY")
+					client, err := api.NewClient("", &token)
+					require.NoError(t, err)
+
+					vcs, err := client.GetVirtualClusters()
+					require.NoError(t, err)
+
+					var virtualCluster *api.VirtualCluster
+					for _, vc := range vcs {
+						if vc.Name == fmt.Sprintf("vcn_%s", nameSuffix) {
+							virtualCluster = &vc
+							break
+						}
+					}
+					require.NotNil(t, virtualCluster)
+
+					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
+					require.NoError(t, err)
+				},
+				Config:             testAccVirtualClusterCredentialsResource_withSuperuser(true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
 func TestAccVirtualClusterCredentialsResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -31,14 +31,14 @@ func TestAccVirtualClusterResourceDeletePlan(t *testing.T) {
 					vcs, err := client.GetVirtualClusters()
 					require.NoError(t, err)
 
-					var virtualCluster *api.VirtualCluster
+					var virtualCluster api.VirtualCluster
 					for _, vc := range vcs {
 						if vc.Name == fmt.Sprintf("vcn_test_acc_%s", vcNameSuffix) {
-							virtualCluster = &vc
+							virtualCluster = vc
 							break
 						}
 					}
-					require.NotNil(t, virtualCluster)
+					require.NotEmpty(t, virtualCluster.ID)
 
 					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
 					require.NoError(t, err)

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -2,13 +2,54 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
 	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
 )
+
+func TestAccVirtualClusterResourceDeletePlan(t *testing.T) {
+	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVirtualClusterResource_withPartialConfiguration(false, vcNameSuffix),
+				Check:  testAccVirtualClusterResourceCheck_BYOC(false, true, 1),
+			},
+			{
+				PreConfig: func() {
+					token := os.Getenv("WARPSTREAM_API_KEY")
+					client, err := api.NewClient("", &token)
+					require.NoError(t, err)
+
+					vcs, err := client.GetVirtualClusters()
+					require.NoError(t, err)
+
+					var virtualCluster *api.VirtualCluster
+					for _, vc := range vcs {
+						if vc.Name == fmt.Sprintf("vcn_test_acc_%s", vcNameSuffix) {
+							virtualCluster = &vc
+							break
+						}
+					}
+					require.NotNil(t, virtualCluster)
+
+					err = client.DeleteVirtualCluster(virtualCluster.ID, virtualCluster.Name)
+					require.NoError(t, err)
+				},
+				Config:             testAccVirtualClusterResource_withPartialConfiguration(false, vcNameSuffix),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
 func TestAccVirtualClusterResource(t *testing.T) {
 	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)


### PR DESCRIPTION
This modifies logic on all resources to properly handle deletion outside of terraform.

If a resource is deleted a plan will no longer fail when a 404 is returned. If a resource is deleted a destroy will no longer fail when a 404 is returned.

Topics have no been modified because the API returns a 500 instead of a 404. Topics will get updated once the API is fixed.