### PR TITLE
Remove goreleaser deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: [ 'zip' ]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:


### PR DESCRIPTION
From this run: https://github.com/warpstreamlabs/terraform-provider-warpstream/actions/runs/13548903581/job/37867410075

```
setting defaults
    • DEPRECATED: 
archives.format
 should not be used anymore, check https://goreleaser.com/deprecations#archivesformat 
```