### PR TITLE
Only run test during business days

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ on:
     branches:
       - main
   schedule:
-    # Run daily at 6 am UTC
-    - cron:  '0 6 * * *'
+    # Run every business day at 6 am UTC
+    - cron:  '0 6 * * 1-5'
 
 # Testing only needs permissions to read the repository contents.
 permissions:


### PR DESCRIPTION
Avoid unnecessary work and spam during the week end.