### PR TITLE
Implement deletion protection for virtual clusters.

### DIFF
--- a/docs/data-sources/virtual_cluster.md
+++ b/docs/data-sources/virtual_cluster.md
@@ -82,3 +82,4 @@ Read-Only:
 - `default_num_partitions` (Number)
 - `default_retention_millis` (Number)
 - `enable_acls` (Boolean)
+- `enable_deletion_protection` (Boolean)

--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -86,6 +86,7 @@ Optional:
 - `default_num_partitions` (Number) Number of partitions created by default.
 - `default_retention_millis` (Number) Default retention for topics that are created automatically using Kafka's topic auto-creation feature.
 - `enable_acls` (Boolean) Enable ACLs, defaults to `false`. See [Configure ACLs](https://docs.warpstream.com/warpstream/configuration/configure-acls)
+- `enable_deletion_protection` (Boolean) Enable deletion protection, defaults to `false`. If set to true, it is impossible to delete this cluster. enable_deletion_protection needs to be set to false before deleting the cluster.
 
 
 <a id="nestedatt--agent_keys"></a>

--- a/internal/provider/api/models.go
+++ b/internal/provider/api/models.go
@@ -63,10 +63,11 @@ type VirtualClusterCredentials struct {
 }
 
 type VirtualClusterConfiguration struct {
-	AclsEnabled            bool  `json:"are_acls_enabled"`
-	AutoCreateTopic        bool  `json:"is_auto_create_topic_enabled"`
-	DefaultNumPartitions   int64 `json:"default_num_partitions"`
-	DefaultRetentionMillis int64 `json:"default_retention_millis"`
+	AclsEnabled              bool  `json:"are_acls_enabled"`
+	AutoCreateTopic          bool  `json:"is_auto_create_topic_enabled"`
+	DefaultNumPartitions     int64 `json:"default_num_partitions"`
+	DefaultRetentionMillis   int64 `json:"default_retention_millis"`
+	EnableDeletionProtection bool  `json:"enable_deletion_protection"`
 }
 
 type Topic struct {

--- a/internal/provider/virtual_cluster.go
+++ b/internal/provider/virtual_cluster.go
@@ -37,27 +37,30 @@ type virtualClusterResourceModel struct {
 }
 
 type virtualClusterConfigurationModel struct {
-	AclsEnabled          types.Bool  `tfsdk:"enable_acls"`
-	AutoCreateTopic      types.Bool  `tfsdk:"auto_create_topic"`
-	DefaultNumPartitions types.Int64 `tfsdk:"default_num_partitions"`
-	DefaultRetention     types.Int64 `tfsdk:"default_retention_millis"`
+	AclsEnabled              types.Bool  `tfsdk:"enable_acls"`
+	AutoCreateTopic          types.Bool  `tfsdk:"auto_create_topic"`
+	DefaultNumPartitions     types.Int64 `tfsdk:"default_num_partitions"`
+	DefaultRetention         types.Int64 `tfsdk:"default_retention_millis"`
+	EnableDeletionProtection types.Bool  `tfsdk:"enable_deletion_protection"`
 }
 
 func (m virtualClusterConfigurationModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"auto_create_topic":        types.BoolType,
-		"default_num_partitions":   types.Int64Type,
-		"default_retention_millis": types.Int64Type,
-		"enable_acls":              types.BoolType,
+		"auto_create_topic":          types.BoolType,
+		"default_num_partitions":     types.Int64Type,
+		"default_retention_millis":   types.Int64Type,
+		"enable_acls":                types.BoolType,
+		"enable_deletion_protection": types.BoolType,
 	}
 }
 
 func (m virtualClusterConfigurationModel) DefaultObject() map[string]attr.Value {
 	return map[string]attr.Value{
-		"auto_create_topic":        types.BoolValue(true),
-		"default_num_partitions":   types.Int64Value(1),
-		"default_retention_millis": types.Int64Value(86400000),
-		"enable_acls":              types.BoolValue(false),
+		"auto_create_topic":          types.BoolValue(true),
+		"default_num_partitions":     types.Int64Value(1),
+		"default_retention_millis":   types.Int64Value(86400000),
+		"enable_acls":                types.BoolValue(false),
+		"enable_deletion_protection": types.BoolValue(false),
 	}
 }
 

--- a/internal/provider/virtual_cluster_data_source.go
+++ b/internal/provider/virtual_cluster_data_source.go
@@ -117,6 +117,9 @@ func (d *virtualClusterDataSource) Schema(_ context.Context, _ datasource.Schema
 					"enable_acls": schema.BoolAttribute{
 						Computed: true,
 					},
+					"enable_deletion_protection": schema.BoolAttribute{
+						Computed: true,
+					},
 				},
 				Computed: true,
 			},
@@ -265,10 +268,11 @@ func (d *virtualClusterDataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	cfgState := virtualClusterConfigurationModel{
-		AclsEnabled:          types.BoolValue(cfg.AclsEnabled),
-		AutoCreateTopic:      types.BoolValue(cfg.AutoCreateTopic),
-		DefaultNumPartitions: types.Int64Value(cfg.DefaultNumPartitions),
-		DefaultRetention:     types.Int64Value(cfg.DefaultRetentionMillis),
+		AclsEnabled:              types.BoolValue(cfg.AclsEnabled),
+		AutoCreateTopic:          types.BoolValue(cfg.AutoCreateTopic),
+		DefaultNumPartitions:     types.Int64Value(cfg.DefaultNumPartitions),
+		DefaultRetention:         types.Int64Value(cfg.DefaultRetentionMillis),
+		EnableDeletionProtection: types.BoolValue(cfg.EnableDeletionProtection),
 	}
 
 	// Set configuration state

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -241,6 +241,12 @@ This resource allows you to create, update and delete virtual clusters.
 						Computed:    true,
 						Default:     booldefault.StaticBool(false),
 					},
+					"enable_deletion_protection": schema.BoolAttribute{
+						Description: "Enable deletion protection, defaults to `false`. If set to true, it is impossible to delete this cluster. enable_deletion_protection needs to be set to false before deleting the cluster.",
+						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
+					},
 				},
 				Description: "Virtual Cluster Configuration.",
 				Optional:    true,
@@ -571,10 +577,11 @@ func (r *virtualClusterResource) readConfiguration(ctx context.Context, cluster 
 	tflog.Debug(ctx, fmt.Sprintf("Configuration: %+v", *cfg))
 
 	cfgState := virtualClusterConfigurationModel{
-		AclsEnabled:          types.BoolValue(cfg.AclsEnabled),
-		AutoCreateTopic:      types.BoolValue(cfg.AutoCreateTopic),
-		DefaultNumPartitions: types.Int64Value(cfg.DefaultNumPartitions),
-		DefaultRetention:     types.Int64Value(cfg.DefaultRetentionMillis),
+		AclsEnabled:              types.BoolValue(cfg.AclsEnabled),
+		AutoCreateTopic:          types.BoolValue(cfg.AutoCreateTopic),
+		DefaultNumPartitions:     types.Int64Value(cfg.DefaultNumPartitions),
+		DefaultRetention:         types.Int64Value(cfg.DefaultRetentionMillis),
+		EnableDeletionProtection: types.BoolValue(cfg.EnableDeletionProtection),
 	}
 
 	// Set configuration state
@@ -602,10 +609,11 @@ func (r *virtualClusterResource) applyConfiguration(ctx context.Context, plan vi
 
 	// Update virtual cluster configuration
 	cfg := &api.VirtualClusterConfiguration{
-		AclsEnabled:            cfgPlan.AclsEnabled.ValueBool(),
-		AutoCreateTopic:        cfgPlan.AutoCreateTopic.ValueBool(),
-		DefaultNumPartitions:   cfgPlan.DefaultNumPartitions.ValueInt64(),
-		DefaultRetentionMillis: cfgPlan.DefaultRetention.ValueInt64(),
+		AclsEnabled:              cfgPlan.AclsEnabled.ValueBool(),
+		AutoCreateTopic:          cfgPlan.AutoCreateTopic.ValueBool(),
+		DefaultNumPartitions:     cfgPlan.DefaultNumPartitions.ValueInt64(),
+		DefaultRetentionMillis:   cfgPlan.DefaultRetention.ValueInt64(),
+		EnableDeletionProtection: cfgPlan.EnableDeletionProtection.ValueBool(),
 	}
 	err := r.client.UpdateConfiguration(*cfg, cluster)
 	if err != nil {


### PR DESCRIPTION
Adds a new "enable_deletion_protection" field to
the configuration of a virtual cluster.

This field is used to prevent accidental deletion of a
virtual cluster.

When set to true, it's impossible to delete the
virtual cluster in the UI, or the API, or terraform.

```
resource "warpstream_virtual_cluster" "test" {
  name = "vcn_test_"
  configuration = {
    enable_deletion_protection = true
  }
}
```