### PR TITLE
Add cluster tier support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@
 *.tfstate
 *.tfstate.*
 
+# idea project files
+.idea/
+
 **/.terraform.lock.hcl

--- a/docs/data-sources/virtual_cluster.md
+++ b/docs/data-sources/virtual_cluster.md
@@ -52,6 +52,7 @@ output "vc_default_id" {
 - `created_at` (String)
 - `id` (String) The ID of this resource.
 - `tags` (Map of String) Tags associated with the virtual cluster.
+- `tier` (String)
 - `type` (String)
 - `workspace_id` (String) Workspace ID. ID of the workspace to which the virtual cluster belongs. Assigned based on the workspace of the application key used to authenticate the WarpStream provider. Cannot be changed after creation.
 

--- a/docs/resources/agent_key.md
+++ b/docs/resources/agent_key.md
@@ -30,6 +30,7 @@ provider "warpstream" {
 
 resource "warpstream_virtual_cluster" "tf_example_agent_keys" {
   name = "vcn_tf_example_agent_keys"
+  tier = "dev"
 }
 
 resource "warpstream_agent_key" "example_agent_key" {

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -32,6 +32,7 @@ provider "warpstream" {
 
 resource "warpstream_virtual_cluster" "tf_example_pipelines" {
   name = "vcn_tf_example_pipelines"
+  tier = "dev"
 }
 
 resource "warpstream_pipeline" "example_bento_pipeline" {

--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -18,10 +18,12 @@ The WarpStream provider must be authenticated with an application key to consume
 ```terraform
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test"
+  tier = "dev"
 }
 
 resource "warpstream_virtual_cluster" "test_with_acls" {
   name = "vcn_test_acls"
+  tier = "dev"
   configuration = {
     enable_acls = true
   }
@@ -29,6 +31,7 @@ resource "warpstream_virtual_cluster" "test_with_acls" {
 
 resource "warpstream_virtual_cluster" "test_configuration" {
   name = "vcn_test_configuration"
+  tier = "dev"
   configuration = {
     auto_create_topic        = true
     default_num_partitions   = 1
@@ -39,6 +42,7 @@ resource "warpstream_virtual_cluster" "test_configuration" {
 
 resource "warpstream_virtual_cluster" "test_cloud_region" {
   name = "vcn_test_cloud_region"
+  tier = "dev"
   cloud = {
     provider = "aws"
     region   = "ap-southeast-1"
@@ -52,6 +56,7 @@ resource "warpstream_virtual_cluster" "test_cloud_region" {
 ### Required
 
 - `name` (String) Virtual Cluster Name.
+- `tier` (String) Virtual Cluster Tier. Currently, the valid virtual cluster tiers are `dev`, 'pro', 'fundamentals'.
 
 ### Optional
 

--- a/docs/resources/virtual_cluster_credentials.md
+++ b/docs/resources/virtual_cluster_credentials.md
@@ -18,6 +18,7 @@ The WarpStream provider must be authenticated with an application key to consume
 ```terraform
 resource "warpstream_virtual_cluster" "xxx" {
   name = "vcn_xxx"
+  tier = "dev"
 }
 
 resource "warpstream_virtual_cluster_credentials" "test" {

--- a/examples/byoc-with-topics/main.tf
+++ b/examples/byoc-with-topics/main.tf
@@ -15,6 +15,7 @@ provider "warpstream" {
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test"
   type = "byoc"
+  tier = "dev"
   configuration = {
     auto_create_topic        = false
     default_num_partitions   = 1

--- a/examples/resources/warpstream_agent_key/resource.tf
+++ b/examples/resources/warpstream_agent_key/resource.tf
@@ -12,6 +12,7 @@ provider "warpstream" {
 
 resource "warpstream_virtual_cluster" "tf_example_agent_keys" {
   name = "vcn_tf_example_agent_keys"
+  tier = "dev"
 }
 
 resource "warpstream_agent_key" "example_agent_key" {

--- a/examples/resources/warpstream_pipeline/resource.tf
+++ b/examples/resources/warpstream_pipeline/resource.tf
@@ -12,6 +12,7 @@ provider "warpstream" {
 
 resource "warpstream_virtual_cluster" "tf_example_pipelines" {
   name = "vcn_tf_example_pipelines"
+  tier = "dev"
 }
 
 resource "warpstream_pipeline" "example_bento_pipeline" {

--- a/examples/resources/warpstream_virtual_cluster/resource.tf
+++ b/examples/resources/warpstream_virtual_cluster/resource.tf
@@ -1,9 +1,11 @@
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test"
+  tier = "dev"
 }
 
 resource "warpstream_virtual_cluster" "test_with_acls" {
   name = "vcn_test_acls"
+  tier = "dev"
   configuration = {
     enable_acls = true
   }
@@ -11,6 +13,7 @@ resource "warpstream_virtual_cluster" "test_with_acls" {
 
 resource "warpstream_virtual_cluster" "test_configuration" {
   name = "vcn_test_configuration"
+  tier = "dev"
   configuration = {
     auto_create_topic        = true
     default_num_partitions   = 1
@@ -21,6 +24,7 @@ resource "warpstream_virtual_cluster" "test_configuration" {
 
 resource "warpstream_virtual_cluster" "test_cloud_region" {
   name = "vcn_test_cloud_region"
+  tier = "dev"
   cloud = {
     provider = "aws"
     region   = "ap-southeast-1"

--- a/examples/resources/warpstream_virtual_cluster_credentials/resource.tf
+++ b/examples/resources/warpstream_virtual_cluster_credentials/resource.tf
@@ -1,5 +1,6 @@
 resource "warpstream_virtual_cluster" "xxx" {
   name = "vcn_xxx"
+  tier = "dev"
 }
 
 resource "warpstream_virtual_cluster_credentials" "test" {

--- a/internal/provider/agent_keys_data_source_test.go
+++ b/internal/provider/agent_keys_data_source_test.go
@@ -24,6 +24,7 @@ func testAccAgentKeyDataSource() string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "default" {
 	name = "vcn_%s"
+    tier = "dev"
 }
 
 data "warpstream_agent_keys" "test" {

--- a/internal/provider/api/models.go
+++ b/internal/provider/api/models.go
@@ -2,6 +2,7 @@ package api
 
 type ClusterParameters struct {
 	Type        string
+	Tier        string
 	Region      *string
 	RegionGroup *string
 	Cloud       string
@@ -65,11 +66,12 @@ type VirtualClusterCredentials struct {
 }
 
 type VirtualClusterConfiguration struct {
-	AclsEnabled              bool  `json:"are_acls_enabled"`
-	AutoCreateTopic          bool  `json:"is_auto_create_topic_enabled"`
-	DefaultNumPartitions     int64 `json:"default_num_partitions"`
-	DefaultRetentionMillis   int64 `json:"default_retention_millis"`
-	EnableDeletionProtection bool  `json:"enable_deletion_protection"`
+	AclsEnabled              bool   `json:"are_acls_enabled"`
+	AutoCreateTopic          bool   `json:"is_auto_create_topic_enabled"`
+	DefaultNumPartitions     int64  `json:"default_num_partitions"`
+	DefaultRetentionMillis   int64  `json:"default_retention_millis"`
+	EnableDeletionProtection bool   `json:"enable_deletion_protection"`
+	Tier                     string `json:"tier,omitempty"`
 }
 
 type Topic struct {

--- a/internal/provider/api/virtual_cluster.go
+++ b/internal/provider/api/virtual_cluster.go
@@ -36,6 +36,7 @@ type VirtualClusterDescribeRequest struct {
 type VirtualClusterCreateRequest struct {
 	Name          string            `json:"virtual_cluster_name"`
 	Type          string            `json:"virtual_cluster_type,omitempty"`
+	Tier          string            `json:"virtual_cluster_tier,omitempty"`
 	Region        *string           `json:"virtual_cluster_region,omitempty"`
 	RegionGroup   *string           `json:"virtual_cluster_region_group,omitempty"`
 	CloudProvider string            `json:"virtual_cluster_cloud_provider,omitempty"`
@@ -84,6 +85,7 @@ func (c *Client) CreateVirtualCluster(name string, opts ClusterParameters) (*Vir
 	payload, err := json.Marshal(VirtualClusterCreateRequest{
 		Name:          trimmed,
 		Type:          opts.Type,
+		Tier:          opts.Tier,
 		Region:        opts.Region,
 		RegionGroup:   opts.RegionGroup,
 		CloudProvider: opts.Cloud,

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -120,6 +120,7 @@ func testBentoPipeline(vcNameSuffix string) string {
 	virtualClusterResource := fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
 	name = "vcn_test_acc_%s"
+    tier = "dev"
 }`, vcNameSuffix)
 	return providerConfig + virtualClusterResource + `
 resource "warpstream_pipeline" "test_pipeline" {
@@ -160,6 +161,7 @@ func testOrbitPipeline() string {
 	virtualClusterResource := fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
 	name = "vcn_test_acc_kobe_%s"
+    tier = "dev"
 }`, acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	return providerConfig + virtualClusterResource + `
 resource "warpstream_pipeline" "test_pipeline" {

--- a/internal/provider/schema_registry_data_source_test.go
+++ b/internal/provider/schema_registry_data_source_test.go
@@ -22,6 +22,7 @@ func TestAccSchemaRegistryDataSource(t *testing.T) {
 		vcNameSuffix,
 		api.ClusterParameters{
 			Type:   types.VirtualClusterTypeSchemaRegistry,
+			Tier:   types.VirtualClusterTierPro,
 			Region: &region,
 			Cloud:  "aws",
 		},
@@ -98,6 +99,7 @@ func TestAccSchemaRegistryDatasource_BYOCNotWork(t *testing.T) {
 		vcNameSuffix,
 		api.ClusterParameters{
 			Type:   types.VirtualClusterTypeBYOC,
+			Tier:   types.VirtualClusterTierPro,
 			Region: &region,
 			Cloud:  "aws",
 		},

--- a/internal/provider/schema_registry_resource.go
+++ b/internal/provider/schema_registry_resource.go
@@ -164,6 +164,7 @@ func (r *schemaRegistryResource) Create(ctx context.Context, req resource.Create
 		plan.Name.ValueString(),
 		api.ClusterParameters{
 			Type:   warpstreamtypes.VirtualClusterTypeSchemaRegistry,
+			Tier:   warpstreamtypes.VirtualClusterTierPro,
 			Region: cloudPlan.Region.ValueStringPointer(),
 			Cloud:  cloudPlan.Provider.ValueString(),
 		})

--- a/internal/provider/topic_resource_test.go
+++ b/internal/provider/topic_resource_test.go
@@ -114,6 +114,7 @@ func TestAccTopicResource(t *testing.T) {
 				Config: providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "default" {
 	name = "vcn_%s"
+    tier = "dev"
 }
 
 resource "warpstream_topic" "topic" {
@@ -146,6 +147,7 @@ func testAccTopicAndClusterResource(clusterName string) string {
 	return providerConfig + fmt.Sprintf(`
 	resource "warpstream_virtual_cluster" "default" {
 		name = "vcn_%s"
+        tier = "dev"
 	}
 	resource "warpstream_topic" "topic" {
 	  topic_name         = "test"

--- a/internal/provider/types/types.go
+++ b/internal/provider/types/types.go
@@ -3,4 +3,10 @@ package types
 const (
 	VirtualClusterTypeBYOC           = "byoc"
 	VirtualClusterTypeSchemaRegistry = "byoc_schema_registry"
+
+	// legacy is only available for certain tenants, this is controlled on the Warpstream side.
+	VirtualClusterTierLegacy       = "legacy"
+	VirtualClusterTierDev          = "dev"
+	VirtualClusterTierFundamentals = "fundamentals"
+	VirtualClusterTierPro          = "pro"
 )

--- a/internal/provider/virtual_cluster.go
+++ b/internal/provider/virtual_cluster.go
@@ -10,6 +10,7 @@ type virtualClusterDataSourceModel struct {
 	ID            types.String     `tfsdk:"id"`
 	Name          types.String     `tfsdk:"name"`
 	Type          types.String     `tfsdk:"type"`
+	Tier          types.String     `tfsdk:"tier"`
 	AgentKeys     *[]agentKeyModel `tfsdk:"agent_keys"`
 	AgentPoolID   types.String     `tfsdk:"agent_pool_id"`
 	AgentPoolName types.String     `tfsdk:"agent_pool_name"`
@@ -26,6 +27,7 @@ type virtualClusterResourceModel struct {
 	ID            types.String `tfsdk:"id"`
 	Name          types.String `tfsdk:"name"`
 	Type          types.String `tfsdk:"type"`
+	Tier          types.String `tfsdk:"tier"`
 	AgentKeys     types.List   `tfsdk:"agent_keys"`
 	AgentPoolID   types.String `tfsdk:"agent_pool_id"`
 	AgentPoolName types.String `tfsdk:"agent_pool_name"`

--- a/internal/provider/virtual_cluster_credentials_resource_test.go
+++ b/internal/provider/virtual_cluster_credentials_resource_test.go
@@ -134,6 +134,7 @@ func testAccVirtualClusterCredentialsResource_withSuperuser(su bool) string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "default" {
 	name = "vcn_%s"
+    tier = "dev"
 }
 
 resource "warpstream_virtual_cluster_credentials" "test" {
@@ -149,6 +150,7 @@ func testAccVirtualClusterCredentialsResource_vcField(vcFieldName string) string
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "default" {
 	name = "vcn_%s"
+    tier = "dev"
 }
 
 resource "warpstream_virtual_cluster_credentials" "test" {
@@ -164,6 +166,7 @@ func testAccVirtualClusterCredentialsResource_vcFieldMissing() string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "default" {
 	name = "vcn_%s"
+    tier = "dev"
 }
 
 resource "warpstream_virtual_cluster_credentials" "test" {

--- a/internal/provider/virtual_cluster_data_source_test.go
+++ b/internal/provider/virtual_cluster_data_source_test.go
@@ -22,6 +22,7 @@ func TestAccVirtualClusterDataSource(t *testing.T) {
 		vcNameSuffix,
 		api.ClusterParameters{
 			Type:   types.VirtualClusterTypeBYOC,
+			Tier:   types.VirtualClusterTierPro,
 			Region: &region,
 			Cloud:  "aws",
 			Tags:   map[string]string{"test_tag": "test_value"},
@@ -114,6 +115,7 @@ func TestAccVirtualClusterDatasource_SchemaRegistryNotWork(t *testing.T) {
 		vcNameSuffix,
 		api.ClusterParameters{
 			Type:   types.VirtualClusterTypeSchemaRegistry,
+			Tier:   types.VirtualClusterTierPro,
 			Region: &region,
 			Cloud:  "aws",
 		},

--- a/internal/provider/virtual_cluster_resource.go
+++ b/internal/provider/virtual_cluster_resource.go
@@ -350,11 +350,12 @@ func (r *virtualClusterResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Describe created virtual cluster
-	cluster, err = r.client.GetVirtualCluster(cluster.ID)
+	clusterID := cluster.ID
+	cluster, err = r.client.GetVirtualCluster(clusterID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading WarpStream Virtual Cluster",
-			"Could not read WarpStream Virtual Cluster ID "+cluster.ID+": "+err.Error(),
+			"Could not read WarpStream Virtual Cluster ID "+clusterID+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/provider/virtual_cluster_resource_test.go
+++ b/internal/provider/virtual_cluster_resource_test.go
@@ -82,6 +82,7 @@ func testAccVirtualClusterResource_removeDeletionProtection(vcNameSuffix string)
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
+  tier = "fundamentals"
   configuration = {
     enable_deletion_protection = false
   }
@@ -92,6 +93,7 @@ func testAccVirtualClusterResource(vcNameSuffix string) string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
+  tier = "fundamentals"
 }`, vcNameSuffix)
 }
 
@@ -102,6 +104,7 @@ func testAccVirtualClusterResource_withPartialConfiguration(
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
+  tier = "fundamentals"
   configuration = {
     enable_acls = %t
   }
@@ -117,6 +120,7 @@ func testAccVirtualClusterResource_withConfiguration(
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_virtual_cluster" "test" {
   name = "vcn_test_acc_%s"
+  tier = "fundamentals"
   configuration = {
     enable_acls = %t
     default_num_partitions = %d

--- a/internal/provider/virtual_clusters_data_source_test.go
+++ b/internal/provider/virtual_clusters_data_source_test.go
@@ -26,6 +26,7 @@ func TestAccVirtualClustersDataSource(t *testing.T) {
 		vcNameSuffix,
 		api.ClusterParameters{
 			Type:   types.VirtualClusterTypeBYOC,
+			Tier:   types.VirtualClusterTierPro,
 			Region: &region,
 			Cloud:  "aws",
 		},


### PR DESCRIPTION
Breaking change: add a new mandatory "tier" attribute in the "warpstream_virtual_cluster" resource.
More info can be found here: https://www.warpstream.com/pricing