### PR TITLE
feat: allow import of `virtual_cluster_credentials`

### DIFF
--- a/docs/resources/virtual_cluster_credentials.md
+++ b/docs/resources/virtual_cluster_credentials.md
@@ -56,5 +56,15 @@ output "vcc_test_password" {
 
 - `created_at` (String) Virtual Cluster Credentials Creation Timestamp.
 - `id` (String) Virtual Cluster Credentials ID.
-- `password` (String, Sensitive) Password.
+- `password` (String, Sensitive) Password. Only available immediately after creation. Not retrievable. If importing, this value will be unset.
 - `username` (String) Username.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Virtual Cluster Credentials can be imported by specifying the identifier.
+# NOTE: this won't fetch the value of the `password` field when importing.
+terraform import warpstream_virtual_cluster_credentials.example ccn_XXXXXXXXXX
+```

--- a/examples/resources/warpstream_virtual_cluster_credentials/import.sh
+++ b/examples/resources/warpstream_virtual_cluster_credentials/import.sh
@@ -1,0 +1,3 @@
+# Virtual Cluster Credentials can be imported by specifying the identifier.
+# NOTE: this won't fetch the value of the `password` field when importing.
+terraform import warpstream_virtual_cluster_credentials.example ccn_XXXXXXXXXX

--- a/internal/provider/utils/modifiers.go
+++ b/internal/provider/utils/modifiers.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// ignoreDiffPlanModifier is a custom plan modifier for string attributes that
+// always sets the planned value to the state value, effectively suppressing
+// differences.
+type IgnoreDiffPlanModifier struct{}
+
+func (m IgnoreDiffPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.StateValue.IsUnknown() && !req.StateValue.IsNull() {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func (m IgnoreDiffPlanModifier) Description(ctx context.Context) string {
+	return "Always use the state value to suppress differences for this attribute."
+}
+
+func (m IgnoreDiffPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}

--- a/internal/provider/virtual_cluster_credentials_resource.go
+++ b/internal/provider/virtual_cluster_credentials_resource.go
@@ -134,9 +134,13 @@ The WarpStream provider must be authenticated with an application key to consume
 				Computed:    true,
 			},
 			"password": schema.StringAttribute{
-				Description: "Password.",
+				Description: "Password. Only available immediately after creation. Not retrievable. If importing, this value will be unset.",
 				Computed:    true,
 				Sensitive:   true,
+				PlanModifiers: []planmodifier.String{
+					utils.IgnoreDiffPlanModifier{},
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"cluster_superuser": schema.BoolAttribute{
 				Description: "Whether the user is cluster superuser. If `true`, the credentials will be created with superuser privileges which enables ACL management via the Kafka Admin APIs. If `false`, and cluster ACLs are enabled, and no `ALLOW` ACLs are set, then these credentials will not be able to access the cluster.",
@@ -325,6 +329,15 @@ func (r *virtualClusterCredentialsResource) Delete(ctx context.Context, req reso
 		)
 		return
 	}
+}
+
+// ImportState imports the resource from the state.
+func (r *virtualClusterCredentialsResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }
 
 // getVirtualClusterIDWithDeprecation is a helper to read virtual cluster ID from the new or old field,

--- a/internal/provider/virtual_cluster_credentials_resource_test.go
+++ b/internal/provider/virtual_cluster_credentials_resource_test.go
@@ -93,8 +93,10 @@ func TestAccVirtualClusterCredentialsResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVirtualClusterCredentialsResource_withSuperuser(true),
-				Check:  testAccVirtualClusterCredentialsResourceCheck(true),
+				Config:            testAccVirtualClusterCredentialsResource_withSuperuser(true),
+				Check:             testAccVirtualClusterCredentialsResourceCheck(true),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccVirtualClusterCredentialsResource_withSuperuser(false),


### PR DESCRIPTION
This change allows users to import an existing `virtual_cluster_credentials` Terraform resource.

- **Import support**:
  - Implemented `ImportState` and enabled import tests.
  - Added documentation and an example script for importing credentials.
- **Plan modifier**: Introduced a custom `IgnoreDiffPlanModifier` to suppress diffs for string attributes by defaulting to the state value.

