### PR TITLE
Remove side-effect of creating an agent key whenever a virtual cluster resource is provisioned

### DIFF
--- a/internal/provider/api/virtual_cluster.go
+++ b/internal/provider/api/virtual_cluster.go
@@ -115,12 +115,13 @@ func (c *Client) GetVirtualCluster(id string) (*VirtualCluster, error) {
 }
 
 type ClusterParameters struct {
-	Type        string
-	Tier        string
-	Region      *string
-	RegionGroup *string
-	Cloud       string
-	Tags        map[string]string
+	Type           string
+	Tier           string
+	Region         *string
+	RegionGroup    *string
+	Cloud          string
+	Tags           map[string]string
+	CreateAgentKey bool
 }
 
 // CreateVirtualCluster - Create new virtual cluster.
@@ -139,7 +140,7 @@ func (c *Client) CreateVirtualCluster(name string, opts ClusterParameters) (*Vir
 		RegionGroup:          opts.RegionGroup,
 		CloudProvider:        opts.Cloud,
 		Tags:                 opts.Tags,
-		SkipAgentKeyCreation: true,
+		SkipAgentKeyCreation: !opts.CreateAgentKey,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/provider/api/virtual_cluster.go
+++ b/internal/provider/api/virtual_cluster.go
@@ -73,13 +73,14 @@ type VirtualClusterDescribeRequest struct {
 }
 
 type VirtualClusterCreateRequest struct {
-	Name          string            `json:"virtual_cluster_name"`
-	Type          string            `json:"virtual_cluster_type,omitempty"`
-	Tier          string            `json:"virtual_cluster_tier,omitempty"`
-	Region        *string           `json:"virtual_cluster_region,omitempty"`
-	RegionGroup   *string           `json:"virtual_cluster_region_group,omitempty"`
-	CloudProvider string            `json:"virtual_cluster_cloud_provider,omitempty"`
-	Tags          map[string]string `json:"virtual_cluster_tags,omitempty"`
+	Name                 string            `json:"virtual_cluster_name"`
+	Type                 string            `json:"virtual_cluster_type,omitempty"`
+	Tier                 string            `json:"virtual_cluster_tier,omitempty"`
+	Region               *string           `json:"virtual_cluster_region,omitempty"`
+	RegionGroup          *string           `json:"virtual_cluster_region_group,omitempty"`
+	CloudProvider        string            `json:"virtual_cluster_cloud_provider,omitempty"`
+	Tags                 map[string]string `json:"virtual_cluster_tags,omitempty"`
+	SkipAgentKeyCreation bool              `json:"skip_agent_key_creation,omitempty"`
 }
 
 type VirtualClusterDeleteRequest struct {
@@ -131,13 +132,14 @@ func (c *Client) CreateVirtualCluster(name string, opts ClusterParameters) (*Vir
 		trimmed = strings.TrimPrefix(name, "vcn_")
 	}
 	payload, err := json.Marshal(VirtualClusterCreateRequest{
-		Name:          trimmed,
-		Type:          opts.Type,
-		Tier:          opts.Tier,
-		Region:        opts.Region,
-		RegionGroup:   opts.RegionGroup,
-		CloudProvider: opts.Cloud,
-		Tags:          opts.Tags,
+		Name:                 trimmed,
+		Type:                 opts.Type,
+		Tier:                 opts.Tier,
+		Region:               opts.Region,
+		RegionGroup:          opts.RegionGroup,
+		CloudProvider:        opts.Cloud,
+		Tags:                 opts.Tags,
+		SkipAgentKeyCreation: true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/provider/tests/schema_registry_data_source_test.go
+++ b/internal/provider/tests/schema_registry_data_source_test.go
@@ -20,10 +20,11 @@ func TestAccSchemaRegistryDataSource(t *testing.T) {
 	vc, err := client.CreateVirtualCluster(
 		vcNameSuffix,
 		api.ClusterParameters{
-			Type:   api.VirtualClusterTypeSchemaRegistry,
-			Tier:   api.VirtualClusterTierPro,
-			Region: &region,
-			Cloud:  "aws",
+			Type:           api.VirtualClusterTypeSchemaRegistry,
+			Tier:           api.VirtualClusterTierPro,
+			Region:         &region,
+			Cloud:          "aws",
+			CreateAgentKey: true,
 		},
 	)
 	require.NoError(t, err)

--- a/internal/provider/tests/virtual_cluster_data_source_test.go
+++ b/internal/provider/tests/virtual_cluster_data_source_test.go
@@ -20,11 +20,12 @@ func TestAccVirtualClusterDataSource(t *testing.T) {
 	vc, err := client.CreateVirtualCluster(
 		vcNameSuffix,
 		api.ClusterParameters{
-			Type:   api.VirtualClusterTypeBYOC,
-			Tier:   api.VirtualClusterTierPro,
-			Region: &region,
-			Cloud:  "aws",
-			Tags:   map[string]string{"test_tag": "test_value"},
+			Type:           api.VirtualClusterTypeBYOC,
+			Tier:           api.VirtualClusterTierPro,
+			Region:         &region,
+			Cloud:          "aws",
+			Tags:           map[string]string{"test_tag": "test_value"},
+			CreateAgentKey: true,
 		},
 	)
 	require.NoError(t, err)

--- a/internal/provider/tests/virtual_cluster_resource_test.go
+++ b/internal/provider/tests/virtual_cluster_resource_test.go
@@ -153,8 +153,7 @@ func testAccVirtualClusterResourceCheck(acls bool, autoTopic bool, numParts int6
 
 	if vcType == "byoc" {
 		checks = append(checks,
-			resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "agent_keys.#", "1"),
-			utils.TestCheckResourceAttrStartsWith("warpstream_virtual_cluster.test", "agent_keys.0.name", "akn_virtual_cluster_test_acc_"),
+			resource.TestCheckResourceAttr("warpstream_virtual_cluster.test", "agent_keys.#", "0"),
 			utils.TestCheckResourceAttrMatchesRegex("warpstream_virtual_cluster.test", "bootstrap_url", `kafka\.discoveryv2\..+\.us-east-1\.warpstream\.com:9092`),
 		)
 	}

--- a/internal/provider/tests/virtual_clusters_data_source_test.go
+++ b/internal/provider/tests/virtual_clusters_data_source_test.go
@@ -24,10 +24,11 @@ func TestAccVirtualClustersDataSource(t *testing.T) {
 	vc, err := client.CreateVirtualCluster(
 		vcNameSuffix,
 		api.ClusterParameters{
-			Type:   api.VirtualClusterTypeBYOC,
-			Tier:   api.VirtualClusterTierPro,
-			Region: &region,
-			Cloud:  "aws",
+			Type:           api.VirtualClusterTypeBYOC,
+			Tier:           api.VirtualClusterTierPro,
+			Region:         &region,
+			Cloud:          "aws",
+			CreateAgentKey: true,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Analogous to https://github.com/warpstreamlabs/terraform-provider-warpstream/pull/144

Practitioners generally don't want extra resources created that aren't under Terraform management. Pass a flag to the API's virtual cluster creation endpoint to skip creating an agent key at the same time.