### PR TITLE
Extend workspace resource to support renaming an existing workspace

### DIFF
--- a/internal/provider/api/workspace.go
+++ b/internal/provider/api/workspace.go
@@ -27,6 +27,11 @@ type WorkspaceDeleteRequest struct {
 	ID string `json:"workspace_id"`
 }
 
+type WorkspaceRenameRequest struct {
+	ID   string `json:"workspace_id"`
+	Name string `json:"new_workspace_name"`
+}
+
 // CreateWorkspace - Create new Workspace.
 func (c *Client) CreateWorkspace(name string) (string, error) {
 	payload, err := json.Marshal(WorkspaceCreateRequest{Name: name, SkipApplicationKeyCreation: true})
@@ -115,4 +120,24 @@ func (c *Client) GetWorkspace(workspaceID string) (*Workspace, error) {
 	}
 
 	return nil, ErrNotFound
+}
+
+// RenameWorkspace - Rename a Workspace.
+func (c *Client) RenameWorkspace(workspaceID string, newName string) error {
+	payload, err := json.Marshal(WorkspaceRenameRequest{ID: workspaceID, Name: newName})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/rename_workspace", c.HostURL), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest(req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/provider/tests/workspace_resource_test.go
+++ b/internal/provider/tests/workspace_resource_test.go
@@ -21,6 +21,12 @@ func TestAccAccountKeyWorkspaceResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("warpstream_workspace.test", "created_at"),
 				),
 			},
+			{
+				Config: testAccWorkspaceResource(workspaceNameSuffix + "_renamed"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("warpstream_workspace.test", "name", fmt.Sprintf("test_acc_%s_renamed", workspaceNameSuffix)),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Allow practitioners to rename a workspace after it's been created.