### PR TITLE
fix TestBentoPipelineResourceDeletePlan due to warpstream now adding a default error_handling block when none exists

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -40,6 +40,8 @@ resource "warpstream_pipeline" "example_bento_pipeline" {
   name               = "example_bento_pipeline"
   state              = "running"
   configuration_yaml = <<EOT
+  error_handling:
+    strategy: reject
   input:
     kafka_franz:
         seed_brokers: ["localhost:9092"]

--- a/examples/resources/warpstream_pipeline/resource.tf
+++ b/examples/resources/warpstream_pipeline/resource.tf
@@ -20,6 +20,8 @@ resource "warpstream_pipeline" "example_bento_pipeline" {
   name               = "example_bento_pipeline"
   state              = "running"
   configuration_yaml = <<EOT
+  error_handling:
+    strategy: reject
   input:
     kafka_franz:
         seed_brokers: ["localhost:9092"]

--- a/internal/provider/tests/pipeline_resource_test.go
+++ b/internal/provider/tests/pipeline_resource_test.go
@@ -129,6 +129,8 @@ resource "warpstream_pipeline" "test_pipeline" {
   name               = "test_pipeline"
   state              = "running"
   configuration_yaml = <<EOT
+  error_handling:
+    strategy: reject
   input:
     kafka_franz:
         seed_brokers: ["localhost:9092"]


### PR DESCRIPTION
This causes tf to always think something has changed when it hasn't so we need to add this block to the tests and examples.

WarpStream pipeline documentation will be updated with this new behavior so future users aren't surprised.