### PR TITLE
fix vc and sr provider descriptions to include azure

### DIFF
--- a/docs/resources/schema_registry.md
+++ b/docs/resources/schema_registry.md
@@ -57,7 +57,7 @@ resource "warpstream_schema_registry" "example_schema_registry" {
 
 Optional:
 
-- `provider` (String) Cloud Provider. Valid providers are: `aws` (default) and `gcp`.
+- `provider` (String) Cloud Provider. Valid providers are: `aws` (default), `gcp`, and `azure`.
 - `region` (String) Cloud Region. Defaults to `us-east-1`.
 
 

--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -81,7 +81,7 @@ resource "warpstream_virtual_cluster" "test_cloud_region" {
 
 Optional:
 
-- `provider` (String) Cloud Provider. Valid providers are: `aws` (default) and `gcp`.
+- `provider` (String) Cloud Provider. Valid providers are: `aws` (default), `gcp`, and `azure`.
 - `region` (String) Cloud Region. Defaults to `us-east-1`. Can't be set if `region_group` is set.
 - `region_group` (String) Cloud Region Group. Defaults to null. Can't be set if `region` is set.
 

--- a/internal/provider/datasources/virtual_clusters.go
+++ b/internal/provider/datasources/virtual_clusters.go
@@ -136,12 +136,12 @@ func (d *virtualClustersDataSource) Read(ctx context.Context, req datasource.Rea
 		}
 
 		state.VirtualClusters = append(state.VirtualClusters, vcnState)
+	}
 
-		diags := resp.State.Set(ctx, &state)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 }
 

--- a/internal/provider/resources/schema_registry.go
+++ b/internal/provider/resources/schema_registry.go
@@ -66,7 +66,7 @@ func (r *schemaRegistryResource) Configure(_ context.Context, req resource.Confi
 var registryCloudSchema = schema.SingleNestedAttribute{
 	Attributes: map[string]schema.Attribute{
 		"provider": schema.StringAttribute{
-			Description: "Cloud Provider. Valid providers are: `aws` (default) and `gcp`.",
+			Description: "Cloud Provider. Valid providers are: `aws` (default), `gcp`, and `azure`.",
 			Computed:    true,
 			Optional:    true,
 			Default:     stringdefault.StaticString("aws"),

--- a/internal/provider/resources/virtual_cluster.go
+++ b/internal/provider/resources/virtual_cluster.go
@@ -97,7 +97,7 @@ var (
 	cloudSchema = schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
 			"provider": schema.StringAttribute{
-				Description: "Cloud Provider. Valid providers are: `aws` (default) and `gcp`.",
+				Description: "Cloud Provider. Valid providers are: `aws` (default), `gcp`, and `azure`.",
 				Computed:    true,
 				Optional:    true,
 				Default:     stringdefault.StaticString("aws"),

--- a/internal/provider/tests/virtual_clusters_data_source_test.go
+++ b/internal/provider/tests/virtual_clusters_data_source_test.go
@@ -205,7 +205,7 @@ virtual cluster states. TF probably has a better way to do this but I couldn't f
 	Out: []map[string]string{{"agent_pool_name": "apn_default_80hc"}, {"name": "vcn_streambased"}}
 */
 func attributesMapToVCStatesSlice(attrsSlice map[string]string) ([]map[string]string, error) {
-	vcsMap := make(map[byte]map[string]string)
+	vcsMap := make(map[string]map[string]string)
 	for k, v := range attrsSlice { // k = "virtual_clusters.1.name", v = "vcn_streambased"
 		if k == "%" { // "%" added by TF to represent a map's length.
 			continue
@@ -220,8 +220,10 @@ func attributesMapToVCStatesSlice(attrsSlice map[string]string) ([]map[string]st
 			continue
 		}
 
-		vcKey := suffixedAttribute[0]       // Some byte representing "0" to however many VCs we have.
-		vcAttrName := suffixedAttribute[2:] // E.g. "name"
+		listIndex := strings.Split(suffixedAttribute, ".")[0]
+
+		vcKey := listIndex                                 // Some byte representing "0" to however many VCs we have.
+		vcAttrName := suffixedAttribute[len(listIndex)+1:] // E.g. "name"
 		if _, ok := vcsMap[vcKey]; !ok {
 			vcsMap[vcKey] = map[string]string{
 				vcAttrName: v,

--- a/internal/provider/tests/virtual_clusters_data_source_test.go
+++ b/internal/provider/tests/virtual_clusters_data_source_test.go
@@ -39,8 +39,6 @@ func TestAccVirtualClustersDataSource(t *testing.T) {
 		require.NoError(t, err)
 
 		createdVCs = append(createdVCs, vc)
-
-		t.Logf("Cluster Created: '%s': '%s' from name '%s'", vc.Name, vc.ID, vcNameSuffix)
 	}
 
 	require.NoError(t, err)
@@ -53,12 +51,6 @@ func TestAccVirtualClustersDataSource(t *testing.T) {
 			}
 		}
 	}()
-
-	vcs, err := client.GetVirtualClusters()
-	require.NoError(t, err)
-	for _, vc := range vcs {
-		t.Logf("VC from GetVirtualClusters: %#v", vc)
-	}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -98,10 +90,6 @@ func testCheckVirtualClustersState(t *testing.T, expectedVCs []*api.VirtualClust
 
 		if err != nil {
 			return err
-		}
-
-		for _, vc := range vcs {
-			t.Logf("Found VC from datalookup: %#v", vc)
 		}
 
 		for _, expectedVC := range expectedVCs {

--- a/internal/provider/tests/virtual_clusters_data_source_test.go
+++ b/internal/provider/tests/virtual_clusters_data_source_test.go
@@ -45,7 +45,7 @@ func TestAccVirtualClustersDataSource(t *testing.T) {
 			{
 				Config: testAccVirtualClustersDataSource_default(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckVirtualClustersState(vc),
+					testCheckVirtualClustersState(t, vc),
 				),
 			},
 		},
@@ -65,7 +65,7 @@ resource test suite creates virtual clusters.
 There must be a better way to deserialize the data source's attributes but I couldn't figure it out from the docs.
 https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests/teststep#custom-check-functions
 */
-func testCheckVirtualClustersState(vc *api.VirtualCluster) resource.TestCheckFunc {
+func testCheckVirtualClustersState(t *testing.T, vc *api.VirtualCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceName := "data.warpstream_virtual_clusters.test"
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -77,6 +77,10 @@ func testCheckVirtualClustersState(vc *api.VirtualCluster) resource.TestCheckFun
 
 		if err != nil {
 			return err
+		}
+
+		for _, vc := range vcs {
+			t.Logf("Found VC from datalookup: %#v", vc)
 		}
 
 		err = assertBYOCVC(vcs, vc)

--- a/internal/provider/tests/virtual_clusters_data_source_test.go
+++ b/internal/provider/tests/virtual_clusters_data_source_test.go
@@ -39,6 +39,8 @@ func TestAccVirtualClustersDataSource(t *testing.T) {
 		}
 	}()
 
+	t.Logf("Cluster Created: '%s': '%s' from name '%s'", vc.Name, vc.ID, vcNameSuffix)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
also do a bunch of stuff to fix the `TestAccVirtualClustersDataSource` test and move `resp.State.Set` outside of a loop. 