### PR TITLE
In the pipeline resource, print a warning when a configuration block was automatically removed from the backend

### DIFF
--- a/internal/provider/api/pipeline.go
+++ b/internal/provider/api/pipeline.go
@@ -46,7 +46,8 @@ type HTTPCreatePipelineConfigurationRequest struct {
 }
 
 type HTTPCreatePipelineConfigurationResponse struct {
-	ConfigurationID string `json:"configuration_id"`
+	ConfigurationID string   `json:"configuration_id"`
+	RemovedKeys     []string `json:"removed_keys"`
 }
 
 type HTTPChangePipelineStateRequest struct {

--- a/internal/provider/resources/pipeline.go
+++ b/internal/provider/resources/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -187,6 +188,14 @@ func (r *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 		)
 		return
 	}
+
+	if len(cc.RemovedKeys) > 0 {
+		resp.Diagnostics.AddWarning(
+			"Warning: Removed some blocks from the pipeline configuration.",
+			removedKeysInPipelineConfigurationWarning(cc.RemovedKeys),
+		)
+	}
+
 	plan.ConfigurationID = types.StringValue(cc.ConfigurationID)
 
 	_, err = r.client.ChangePipelineState(ctx, api.HTTPChangePipelineStateRequest{
@@ -335,4 +344,13 @@ func (r *pipelineResource) Delete(ctx context.Context, req resource.DeleteReques
 		)
 		return
 	}
+}
+
+func removedKeysInPipelineConfigurationWarning(removedKeys []string) string {
+	quotedKeys := make([]string, len(removedKeys))
+	for i, key := range removedKeys {
+		quotedKeys[i] = fmt.Sprintf("%q", key)
+	}
+
+	return fmt.Sprintf("The following keys were removed from the pipeline configuration: %s.", strings.Join(quotedKeys, ", "))
 }


### PR DESCRIPTION
Analogous to the warning shown in the pipeline editor web UI.