### PR TITLE
Clean up no longer used warning for removed keys when creating a managed data pipeline configuration

### DIFF
--- a/internal/provider/api/pipeline.go
+++ b/internal/provider/api/pipeline.go
@@ -46,8 +46,7 @@ type HTTPCreatePipelineConfigurationRequest struct {
 }
 
 type HTTPCreatePipelineConfigurationResponse struct {
-	ConfigurationID string   `json:"configuration_id"`
-	RemovedKeys     []string `json:"removed_keys"`
+	ConfigurationID string `json:"configuration_id"`
 }
 
 type HTTPChangePipelineStateRequest struct {

--- a/internal/provider/resources/pipeline.go
+++ b/internal/provider/resources/pipeline.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -188,14 +187,6 @@ func (r *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 		)
 		return
 	}
-
-	if len(cc.RemovedKeys) > 0 {
-		resp.Diagnostics.AddWarning(
-			"Warning: Removed some blocks from the pipeline configuration.",
-			removedKeysInPipelineConfigurationWarning(cc.RemovedKeys),
-		)
-	}
-
 	plan.ConfigurationID = types.StringValue(cc.ConfigurationID)
 
 	_, err = r.client.ChangePipelineState(ctx, api.HTTPChangePipelineStateRequest{
@@ -344,13 +335,4 @@ func (r *pipelineResource) Delete(ctx context.Context, req resource.DeleteReques
 		)
 		return
 	}
-}
-
-func removedKeysInPipelineConfigurationWarning(removedKeys []string) string {
-	quotedKeys := make([]string, len(removedKeys))
-	for i, key := range removedKeys {
-		quotedKeys[i] = fmt.Sprintf("%q", key)
-	}
-
-	return fmt.Sprintf("The following keys were removed from the pipeline configuration: %s.", strings.Join(quotedKeys, ", "))
 }


### PR DESCRIPTION
This reverts commit 89d9508569119a9ee36b74c5f70fac5e652344fc.

The API now returns an error instead of a list of unsupported keys. Stop branching on the list of unsupported keys to print a warning.