### PR TITLE
In the virtual cluster credentials resource deprecate the agent pool field

### DIFF
--- a/docs/resources/virtual_cluster_credentials.md
+++ b/docs/resources/virtual_cluster_credentials.md
@@ -23,7 +23,6 @@ resource "warpstream_virtual_cluster" "xxx" {
 
 resource "warpstream_virtual_cluster_credentials" "test" {
   name               = "ccn_test"
-  agent_pool         = warpstream_virtual_cluster.xxx.agent_pool_id
   virtual_cluster_id = warpstream_virtual_cluster.xxx.id
 }
 
@@ -43,11 +42,11 @@ output "vcc_test_password" {
 
 ### Required
 
-- `agent_pool` (String) Agent Pool ID.
 - `name` (String) Virtual Cluster Credentials Name.
 
 ### Optional
 
+- `agent_pool` (String, Deprecated) Deprecated.
 - `cluster_superuser` (Boolean) Whether the user is cluster superuser. If `true`, the credentials will be created with superuser privileges which enables ACL management via the Kafka Admin APIs. If `false`, and cluster ACLs are enabled, and no `ALLOW` ACLs are set, then these credentials will not be able to access the cluster.
 - `virtual_cluster` (String, Deprecated) Virtual Cluster ID. Deprecated in favor of `virtual_cluster_id`.
 - `virtual_cluster_id` (String) Virtual Cluster ID. Required unless `virtual_cluster` is set.

--- a/examples/byoc-with-topics/main.tf
+++ b/examples/byoc-with-topics/main.tf
@@ -56,5 +56,4 @@ resource "warpstream_virtual_cluster_credentials" "creds" {
   name = "ccn_test"
 
   virtual_cluster_id = warpstream_virtual_cluster.test.id
-  agent_pool         = warpstream_virtual_cluster.test.agent_pool_id
 }

--- a/examples/resources/warpstream_virtual_cluster_credentials/resource.tf
+++ b/examples/resources/warpstream_virtual_cluster_credentials/resource.tf
@@ -5,7 +5,6 @@ resource "warpstream_virtual_cluster" "xxx" {
 
 resource "warpstream_virtual_cluster_credentials" "test" {
   name               = "ccn_test"
-  agent_pool         = warpstream_virtual_cluster.xxx.agent_pool_id
   virtual_cluster_id = warpstream_virtual_cluster.xxx.id
 }
 

--- a/internal/provider/api/virtual_cluster_credentials.go
+++ b/internal/provider/api/virtual_cluster_credentials.go
@@ -15,8 +15,6 @@ type VirtualClusterCredentials struct {
 	UserName         string `json:"username"`
 	Password         string `json:"password"`
 	CreatedAt        string `json:"created_at"`
-	AgentPoolID      string `json:"agent_pool_id"`
-	AgentPoolName    string `json:"agent_pool_name"`
 	ClusterSuperuser bool   `json:"is_cluster_superuser"`
 }
 
@@ -36,7 +34,6 @@ type CredentialsCreateResponse struct {
 
 type CredentialsCreateRequest struct {
 	Name             string `json:"credentials_name"`
-	AgentPoolID      string `json:"agent_pool_id"`
 	VirtualClusterID string `json:"virtual_cluster_id"`
 	ClusterSuperuser bool   `json:"is_cluster_superuser"`
 }
@@ -50,7 +47,6 @@ type CredentialsDeleteRequest struct {
 func (c *Client) CreateCredentials(name string, su bool, vc VirtualCluster) (*VirtualClusterCredentials, error) {
 	payload, err := json.Marshal(CredentialsCreateRequest{
 		Name:             strings.TrimPrefix(name, "ccn_"),
-		AgentPoolID:      vc.AgentPoolID,
 		VirtualClusterID: vc.ID,
 		ClusterSuperuser: su,
 	})
@@ -77,8 +73,6 @@ func (c *Client) CreateCredentials(name string, su bool, vc VirtualCluster) (*Vi
 	vcc := VirtualClusterCredentials{
 		ID:               res.ID,
 		Name:             name,
-		AgentPoolID:      vc.AgentPoolID,
-		AgentPoolName:    vc.AgentPoolName,
 		UserName:         res.UserName,
 		Password:         res.Password,
 		ClusterSuperuser: su,

--- a/internal/provider/resources/virtual_cluster_credentials.go
+++ b/internal/provider/resources/virtual_cluster_credentials.go
@@ -43,7 +43,7 @@ type virtualClusterCredentialsModel struct {
 	UserName            types.String `tfsdk:"username"`
 	Password            types.String `tfsdk:"password"`
 	CreatedAt           types.String `tfsdk:"created_at"`
-	AgentPoolID         types.String `tfsdk:"agent_pool"`
+	AgentPoolID         types.String `tfsdk:"agent_pool"` // Ignored by the backend, deprecated here.
 	VirtualClusterID    types.String `tfsdk:"virtual_cluster_id"`
 	VirtualClusterIDOld types.String `tfsdk:"virtual_cluster"`
 	ClusterSuperuser    types.Bool   `tfsdk:"cluster_superuser"`
@@ -96,8 +96,9 @@ The WarpStream provider must be authenticated with an application key to consume
 				Validators: []validator.String{utils.StartsWith("ccn_")},
 			},
 			"agent_pool": schema.StringAttribute{
-				Description: "Agent Pool ID.",
-				Required:    true,
+				Description:        "Deprecated.",
+				DeprecationMessage: "This field is deprecated and will be ignored. It can be safely removed from your configuration.",
+				Optional:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -196,7 +197,7 @@ func (r *virtualClusterCredentialsResource) Create(ctx context.Context, req reso
 	newPlan := virtualClusterCredentialsModel{
 		ID:               types.StringValue(c.ID),
 		Name:             types.StringValue(c.Name),
-		AgentPoolID:      types.StringValue(c.AgentPoolID),
+		AgentPoolID:      plan.AgentPoolID,
 		CreatedAt:        types.StringValue(c.CreatedAt), // null
 		UserName:         types.StringValue(c.UserName),
 		Password:         types.StringValue(c.Password),
@@ -266,7 +267,7 @@ func (r *virtualClusterCredentialsResource) Read(ctx context.Context, req resour
 		Name:             types.StringValue(c.Name),
 		UserName:         types.StringValue(c.UserName),
 		Password:         state.Password,
-		AgentPoolID:      types.StringValue(c.AgentPoolID),
+		AgentPoolID:      state.AgentPoolID,
 		CreatedAt:        types.StringValue(c.CreatedAt),
 		ClusterSuperuser: types.BoolValue(c.ClusterSuperuser),
 	}

--- a/internal/provider/tests/virtual_cluster_credentials_resource_test.go
+++ b/internal/provider/tests/virtual_cluster_credentials_resource_test.go
@@ -146,7 +146,6 @@ resource "warpstream_virtual_cluster" "default" {
 
 resource "warpstream_virtual_cluster_credentials" "test" {
 	name            = "ccn_test_%s"
-	agent_pool      = warpstream_virtual_cluster.default.agent_pool_id
 	virtual_cluster_id = warpstream_virtual_cluster.default.id
 	cluster_superuser = %t
   }
@@ -162,7 +161,6 @@ resource "warpstream_virtual_cluster" "default" {
 
 resource "warpstream_virtual_cluster_credentials" "test" {
 	name            = "ccn_test_%s"
-	agent_pool      = warpstream_virtual_cluster.default.agent_pool_id
 	%s = warpstream_virtual_cluster.default.id
 	cluster_superuser = false
   }
@@ -178,7 +176,6 @@ resource "warpstream_virtual_cluster" "default" {
 
 resource "warpstream_virtual_cluster_credentials" "test" {
 	name            = "ccn_test_%s"
-	agent_pool      = warpstream_virtual_cluster.default.agent_pool_id
 	cluster_superuser = false
   }
 `, nameSuffix, nameSuffix)


### PR DESCRIPTION
The backend now ignores this field.