### PR TITLE
Add warpstream_tableflow_table resource for table lifecycle management

### DIFF
--- a/examples/tableflow-table/main.tf
+++ b/examples/tableflow-table/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_providers {
+    warpstream = {
+      source = "warpstreamlabs/warpstream"
+    }
+  }
+}
+
+provider "warpstream" {
+  # Use a generic WarpStream API key here, not a cluster-specific Agent key.
+  token = "YOUR_API_KEY"
+}
+
+# Tableflow cluster.
+resource "warpstream_tableflow_cluster" "example" {
+  name = "vcn_dl_example"
+  tier = "dev"
+  cloud = {
+    provider = "aws"
+    region   = "us-east-1"
+  }
+}
+
+# Pipeline that defines the table.
+resource "warpstream_pipeline" "tableflow_pipeline" {
+  virtual_cluster_id = warpstream_tableflow_cluster.example.id
+  name               = "example_tableflow_pipeline"
+  state              = "running"
+  type               = "tableflow"
+  configuration_yaml = <<EOT
+source_clusters:
+  - name: kafka_cluster_1
+    bootstrap_brokers:
+      - hostname: YOUR_KAFKA_HOSTNAME
+        port: 9092
+tables:
+  - source_cluster_name: kafka_cluster_1
+    source_topic: logs
+    source_format: json
+    schema_mode: inline
+    schema:
+      fields:
+        - { name: environment, type: string, id: 1 }
+        - { name: service, type: string, id: 2 }
+        - { name: status, type: string, id: 3 }
+        - { name: message, type: string, id: 4 }
+destination_bucket_url: s3://tableflow-bucket?region=us-east-1
+EOT
+}
+
+# Adopt the table created by the scheduler.
+# Change recreation_key to force a safe table drop + re-creation.
+# Alternatively: terraform apply -replace=warpstream_tableflow_table.logs
+resource "warpstream_tableflow_table" "logs" {
+  virtual_cluster_id = warpstream_tableflow_cluster.example.id
+  table_name         = "kafka_cluster_1__logs"
+  recreation_key     = "v1"
+
+  depends_on = [warpstream_pipeline.tableflow_pipeline]
+}
+
+output "table_uuid" {
+  value = warpstream_tableflow_table.logs.table_uuid
+}
+
+output "table_created_at" {
+  value = warpstream_tableflow_table.logs.created_at
+}

--- a/internal/provider/api/datalake.go
+++ b/internal/provider/api/datalake.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+type DLTable struct {
+	TableName               string `json:"table_name"`
+	TableUUID               string `json:"table_uuid"`
+	SourceStreamName        string `json:"source_stream_name"`
+	SourceClusterName       string `json:"source_cluster_name"`
+	StatsEstimatedByteCount int64  `json:"stats_estimated_byte_count"`
+	StatsEstimatedRowCount  int64  `json:"stats_estimated_row_count"`
+	CreatedAtUnixNanos      uint64 `json:"created_at_unix_nanos"`
+}
+
+type DLListTablesRequest struct {
+	VirtualClusterID string `json:"virtual_cluster_id"`
+}
+
+type DLListTablesResponse struct {
+	Tables []*DLTable `json:"tables"`
+}
+
+type DLGetTableRequest struct {
+	VirtualClusterID string `json:"virtual_cluster_id"`
+	TableUUID        string `json:"table_uuid,omitempty"`
+	TableName        string `json:"table_name,omitempty"`
+}
+
+type DLGetTableResponse struct {
+	Table *DLTable `json:"table"`
+}
+
+type DLDeleteTableRequest struct {
+	VirtualClusterID string `json:"virtual_cluster_id"`
+	TableUUID        string `json:"table_uuid"`
+}
+
+type DLDeleteTableResponse struct{}
+
+func (c *Client) DLListTables(
+	ctx context.Context,
+	req DLListTablesRequest,
+) (DLListTablesResponse, error) {
+	resp := &DLListTablesResponse{}
+	if err := c.doJSONHTTP(ctx, req, "dl/list_tables", resp); err != nil {
+		return DLListTablesResponse{}, fmt.Errorf("error listing datalake tables: %w", err)
+	}
+	return *resp, nil
+}
+
+func (c *Client) DLGetTable(
+	ctx context.Context,
+	req DLGetTableRequest,
+) (DLGetTableResponse, error) {
+	resp := &DLGetTableResponse{}
+	if err := c.doJSONHTTP(ctx, req, "dl/get_table", resp); err != nil {
+		return DLGetTableResponse{}, fmt.Errorf("error getting datalake table: %w", err)
+	}
+	return *resp, nil
+}
+
+func (c *Client) DLDeleteTable(
+	ctx context.Context,
+	req DLDeleteTableRequest,
+) (DLDeleteTableResponse, error) {
+	resp := &DLDeleteTableResponse{}
+	if err := c.doJSONHTTP(ctx, req, "dl/delete_table", resp); err != nil {
+		return DLDeleteTableResponse{}, fmt.Errorf("error deleting datalake table: %w", err)
+	}
+	return *resp, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -170,5 +170,6 @@ func (p *warpstreamProvider) Resources(_ context.Context) []func() resource.Reso
 		resources.NewWorkspaceResource,
 		resources.NewACLResource,
 		resources.NewSSOConfigurationResource,
+		resources.NewTableFlowTableResource,
 	}
 }

--- a/internal/provider/resources/tableflow_table.go
+++ b/internal/provider/resources/tableflow_table.go
@@ -1,0 +1,253 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api"
+	"github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/utils"
+)
+
+var (
+	_ resource.Resource                = &tableflowTableResource{}
+	_ resource.ResourceWithConfigure   = &tableflowTableResource{}
+	_ resource.ResourceWithImportState = &tableflowTableResource{}
+)
+
+func NewTableFlowTableResource() resource.Resource {
+	return &tableflowTableResource{}
+}
+
+type tableflowTableResource struct {
+	client *api.Client
+}
+
+type tableflowTableModel struct {
+	VirtualClusterID  types.String `tfsdk:"virtual_cluster_id"`
+	ID                types.String `tfsdk:"id"`
+	TableName         types.String `tfsdk:"table_name"`
+	RecreationKey     types.String `tfsdk:"recreation_key"`
+	TableUUID         types.String `tfsdk:"table_uuid"`
+	SourceStreamName  types.String `tfsdk:"source_stream_name"`
+	SourceClusterName types.String `tfsdk:"source_cluster_name"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+}
+
+func (r *tableflowTableResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Invalid Provider Configuration",
+			fmt.Sprintf("Expected an API Client instance, but got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *tableflowTableResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tableflow_table"
+}
+
+func (r *tableflowTableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: `Manages a Tableflow table lifecycle. This resource adopts an existing table 
+(created automatically by the Tableflow scheduler from the pipeline configuration) and allows 
+programmatic recreation by changing the recreation_key attribute. When destroyed, the table is 
+deleted via the API and the scheduler will automatically recreate it if the pipeline config 
+still contains the table definition.`,
+		Attributes: map[string]schema.Attribute{
+			"virtual_cluster_id": schema.StringAttribute{
+				Description: "The ID of the Tableflow virtual cluster.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{utils.StartsWithAndAlphanumeric("vci_")},
+			},
+			"table_name": schema.StringAttribute{
+				Description: "The name of the Tableflow table to manage. Must match a table created by the pipeline scheduler.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"recreation_key": schema.StringAttribute{
+				Description: "An arbitrary string whose change forces table recreation (destroy + create). " +
+					"Bump this value (e.g. from \"v1\" to \"v2\") to trigger a safe table drop and re-creation by the scheduler.",
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Description: "Resource identifier in the format virtual_cluster_id/table_uuid.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"table_uuid": schema.StringAttribute{
+				Description: "The UUID of the table, assigned by WarpStream.",
+				Computed:    true,
+			},
+			"source_stream_name": schema.StringAttribute{
+				Description: "The Kafka topic name that feeds this table.",
+				Computed:    true,
+			},
+			"source_cluster_name": schema.StringAttribute{
+				Description: "The name of the source cluster for this table.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The table creation timestamp (RFC3339).",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *tableflowTableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan tableflowTableModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	table, err := r.lookupTable(ctx, plan.VirtualClusterID.ValueString(), plan.TableName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Table Not Found",
+			fmt.Sprintf(
+				"Could not find Tableflow table %q in virtual cluster %q. "+
+					"Ensure the pipeline configuration defines this table and the scheduler has created it. Error: %s",
+				plan.TableName.ValueString(), plan.VirtualClusterID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	populateTableModel(&plan, table)
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *tableflowTableResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state tableflowTableModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	table, err := r.lookupTable(ctx, state.VirtualClusterID.ValueString(), state.TableName.ValueString())
+	if err != nil {
+		if errors.Is(err, api.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading Tableflow Table",
+			fmt.Sprintf("Unable to read table %q: %s", state.TableName.ValueString(), err),
+		)
+		return
+	}
+
+	populateTableModel(&state, table)
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *tableflowTableResource) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"Update Not Supported",
+		"All mutable attributes on warpstream_tableflow_table use RequiresReplace. Update should never be called.",
+	)
+}
+
+func (r *tableflowTableResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state tableflowTableModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.client.DLDeleteTable(ctx, api.DLDeleteTableRequest{
+		VirtualClusterID: state.VirtualClusterID.ValueString(),
+		TableUUID:        state.TableUUID.ValueString(),
+	})
+	if err != nil {
+		if errors.Is(err, api.ErrNotFound) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Deleting Tableflow Table",
+			fmt.Sprintf("Unable to delete table %q (UUID %s): %s",
+				state.TableName.ValueString(), state.TableUUID.ValueString(), err),
+		)
+	}
+}
+
+func (r *tableflowTableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Expected import ID in the format: virtual_cluster_id/table_name",
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("virtual_cluster_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("table_name"), parts[1])...)
+}
+
+func (r *tableflowTableResource) lookupTable(ctx context.Context, virtualClusterID, tableName string) (*api.DLTable, error) {
+	getResp, err := r.client.DLGetTable(ctx, api.DLGetTableRequest{
+		VirtualClusterID: virtualClusterID,
+		TableName:        tableName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if getResp.Table == nil {
+		return nil, fmt.Errorf("table %q not found: %w", tableName, api.ErrNotFound)
+	}
+	return getResp.Table, nil
+}
+
+func populateTableModel(model *tableflowTableModel, table *api.DLTable) {
+	model.ID = types.StringValue(model.VirtualClusterID.ValueString() + "/" + table.TableUUID)
+	model.TableUUID = types.StringValue(table.TableUUID)
+	model.SourceStreamName = types.StringValue(table.SourceStreamName)
+	model.SourceClusterName = types.StringValue(table.SourceClusterName)
+
+	if table.CreatedAtUnixNanos > 0 {
+		sec := int64(table.CreatedAtUnixNanos / 1_000_000_000)
+		nsec := int64(table.CreatedAtUnixNanos % 1_000_000_000)
+		model.CreatedAt = types.StringValue(
+			time.Unix(sec, nsec).UTC().Format(time.RFC3339),
+		)
+	} else {
+		model.CreatedAt = types.StringValue("")
+	}
+}

--- a/internal/provider/tests/tableflow_table_resource_test.go
+++ b/internal/provider/tests/tableflow_table_resource_test.go
@@ -1,0 +1,129 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+var (
+	tableflowTableClusterSuffix = acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+)
+
+func TestTableflowTableResource(t *testing.T) {
+	resourceName := "warpstream_tableflow_table.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the tableflow cluster + pipeline so the scheduler creates the table.
+			{
+				Config: testTableflowTableInfraOnly(tableflowTableClusterSuffix),
+			},
+			// Step 2: Add the tableflow_table resource to adopt the table.
+			{
+				Config: testTableflowTableFull(tableflowTableClusterSuffix, "v1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "table_uuid"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "recreation_key", "v1"),
+				),
+			},
+			// Step 3: Re-apply with same config; plan should be empty.
+			{
+				Config: testTableflowTableFull(tableflowTableClusterSuffix, "v1"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestTableflowTableResourceRecreation(t *testing.T) {
+	resourceName := "warpstream_tableflow_table.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the tableflow cluster + pipeline.
+			{
+				Config: testTableflowTableInfraOnly(tableflowTableClusterSuffix),
+			},
+			// Step 2: Adopt the table with recreation_key = "v1".
+			{
+				Config: testTableflowTableFull(tableflowTableClusterSuffix, "v1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "table_uuid"),
+					resource.TestCheckResourceAttr(resourceName, "recreation_key", "v1"),
+				),
+			},
+			// Step 3: Change recreation_key to "v2"; plan should show replace.
+			{
+				Config: testTableflowTableFull(tableflowTableClusterSuffix, "v2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "table_uuid"),
+					resource.TestCheckResourceAttr(resourceName, "recreation_key", "v2"),
+				),
+			},
+		},
+	})
+}
+
+func testTableflowTableInfraOnly(suffix string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "warpstream_tableflow_cluster" "test" {
+  name = "vcn_dl_tbl_test_%s"
+  tier = "dev"
+  cloud = {
+    provider = "aws"
+    region   = "us-east-1"
+  }
+}
+
+resource "warpstream_pipeline" "test_pipeline" {
+  virtual_cluster_id = warpstream_tableflow_cluster.test.id
+  name               = "test_pipeline"
+  state              = "running"
+  type               = "tableflow"
+  configuration_yaml = <<EOT
+source_clusters:
+  - name: kafka_cluster_1
+    bootstrap_brokers:
+      - hostname: localhost
+        port: 9092
+tables:
+  - source_cluster_name: kafka_cluster_1
+    source_topic: logs
+    source_format: json
+    schema_mode: inline
+    schema:
+      fields:
+        - { name: environment, type: string, id: 1 }
+        - { name: service, type: string, id: 2 }
+destination_bucket_url: s3://test-tableflow-bucket?region=us-east-1
+EOT
+}
+`, suffix)
+}
+
+func testTableflowTableFull(suffix, recreationKey string) string {
+	return testTableflowTableInfraOnly(suffix) + fmt.Sprintf(`
+resource "warpstream_tableflow_table" "test" {
+  virtual_cluster_id = warpstream_tableflow_cluster.test.id
+  table_name         = "kafka_cluster_1__logs"
+  recreation_key     = %q
+
+  depends_on = [warpstream_pipeline.test_pipeline]
+}
+`, recreationKey)
+}


### PR DESCRIPTION
Adds a new warpstream_tableflow_table resource that adopts tables created by the Tableflow scheduler and enables programmatic recreation via a recreation_key attribute. Changing the key triggers a destroy+create cycle, providing a safe way to drop and re-create tables without manual intervention.
New API client methods for datalake table operations (dl/get_table, dl/list_tables, dl/delete_table)
Resource supports Create (adopt by name lookup), Read, Delete, and Import (virtual_cluster_id/table_name)
All mutable attributes use RequiresReplace — no in-place updates
Acceptance tests for adoption, state convergence (ExpectEmptyPlan), and recreation on key change
Example showing usage alongside a pipeline with depends_on