### PR TITLE
Fix terraform inconsistent result when some configs are removed

### DIFF
--- a/internal/provider/resources/topic.go
+++ b/internal/provider/resources/topic.go
@@ -220,6 +220,24 @@ func policyHasCompact(policy string) bool {
 	return false
 }
 
+// filterConfigsToPlan filters API-returned configs to only include those
+// the user explicitly declared in their Terraform config. This prevents
+// Terraform from seeing "inconsistent result after apply" errors when the
+// API returns configs that weren't in the plan.
+func filterConfigsToPlan(apiConfigs map[string]*string, planConfigs []models.TopicConfig) map[string]*string {
+	planned := make(map[string]struct{}, len(planConfigs))
+	for _, c := range planConfigs {
+		planned[c.Name.ValueString()] = struct{}{}
+	}
+	filtered := make(map[string]*string, len(planConfigs))
+	for k, v := range apiConfigs {
+		if _, ok := planned[k]; ok {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
 func (r *topicResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Retrieve values from plan
 	var plan models.Topic
@@ -266,7 +284,8 @@ func (r *topicResource) Create(ctx context.Context, req resource.CreateRequest, 
 		PartitionCount:            types.Int64Value(int64(topic.PartitionCount)),
 	}
 
-	for configName, configValue := range topic.Configs {
+	filteredConfigs := filterConfigsToPlan(topic.Configs, plan.Config)
+	for configName, configValue := range filteredConfigs {
 		name := types.StringValue(configName)
 		value := types.StringPointerValue(configValue)
 		state.Config = append(state.Config, models.TopicConfig{
@@ -328,6 +347,7 @@ func (r *topicResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	previousConfig := state.Config
 	state = models.Topic{
 		ID:               state.ID,
 		VirtualClusterID: state.VirtualClusterID,
@@ -336,7 +356,8 @@ func (r *topicResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 	state.DeletionProtectionEnabled = types.BoolValue(r.parseTopicDeletionEnableFromConfigs(topic.Configs))
 
-	for configName, configValue := range topic.Configs {
+	filteredConfigs := filterConfigsToPlan(topic.Configs, previousConfig)
+	for configName, configValue := range filteredConfigs {
 		name := types.StringValue(configName)
 		value := types.StringPointerValue(configValue)
 		state.Config = append(state.Config, models.TopicConfig{
@@ -409,7 +430,8 @@ func (r *topicResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		PartitionCount:   types.Int64Value(int64(topic.PartitionCount)),
 	}
 	state.DeletionProtectionEnabled = types.BoolValue(r.parseTopicDeletionEnableFromConfigs(topic.Configs))
-	for configName, configValue := range topic.Configs {
+	filteredConfigs := filterConfigsToPlan(topic.Configs, plan.Config)
+	for configName, configValue := range filteredConfigs {
 		name := types.StringValue(configName)
 		value := types.StringPointerValue(configValue)
 		state.Config = append(state.Config, models.TopicConfig{

--- a/internal/provider/resources/topic.go
+++ b/internal/provider/resources/topic.go
@@ -225,13 +225,10 @@ func policyHasCompact(policy string) bool {
 // Terraform from seeing "inconsistent result after apply" errors when the
 // API returns configs that weren't in the plan.
 func filterConfigsToPlan(apiConfigs map[string]*string, planConfigs []models.TopicConfig) map[string]*string {
-	planned := make(map[string]struct{}, len(planConfigs))
-	for _, c := range planConfigs {
-		planned[c.Name.ValueString()] = struct{}{}
-	}
 	filtered := make(map[string]*string, len(planConfigs))
-	for k, v := range apiConfigs {
-		if _, ok := planned[k]; ok {
+	for _, c := range planConfigs {
+		k := c.Name.ValueString()
+		if v, ok := apiConfigs[k]; ok {
 			filtered[k] = v
 		}
 	}

--- a/internal/provider/tests/topic_resource_test.go
+++ b/internal/provider/tests/topic_resource_test.go
@@ -298,6 +298,90 @@ resource "warpstream_topic" "topic" {
 	})
 }
 
+func TestAccTopicResourceTopicTypeConfig(t *testing.T) {
+	var cluster = acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTopicAndClusterResource(cluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					utils.TestCheckResourceAttrStartsWith("warpstream_topic.topic", "virtual_cluster_id", "vci_"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("topic_name"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("partition_count"), knownvalue.Int64Exact(1)),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				Config: providerConfig + fmt.Sprintf(`
+			resource "warpstream_virtual_cluster" "default" {
+				name = "vcn_%s"
+			    tier = "dev"
+			}
+
+			resource "warpstream_topic" "topic" {
+			  topic_name         = "test"
+			  partition_count    = 1
+			  virtual_cluster_id = warpstream_virtual_cluster.default.id
+
+			  config {
+			    name  = "warpstream.topic.type"
+			    value = "classic"
+			  }
+
+			  config {
+			    name = "retention.ms"
+				value = "604800000"
+			  }
+			}
+							`, cluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					utils.TestCheckResourceAttrStartsWith("warpstream_topic.topic", "virtual_cluster_id", "vci_"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("topic_name"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("partition_count"), knownvalue.Int64Exact(1)),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config").AtSliceIndex(0).AtMapKey("name"), knownvalue.StringExact("retention.ms")),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config").AtSliceIndex(0).AtMapKey("value"), knownvalue.StringExact("604800000")),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config").AtSliceIndex(1).AtMapKey("name"), knownvalue.StringExact("warpstream.topic.type")),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config").AtSliceIndex(1).AtMapKey("value"), knownvalue.StringExact("classic")),
+				},
+			},
+			// Remove topic type config and make sure it gets removed properly
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "warpstream_virtual_cluster" "default" {
+	name = "vcn_%s"
+    tier = "dev"
+}
+
+resource "warpstream_topic" "topic" {
+  topic_name         = "test"
+  partition_count    = 1
+  virtual_cluster_id = warpstream_virtual_cluster.default.id
+
+  config {
+    name = "retention.ms"
+	value = "1604800000"
+  }
+}
+				`, cluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					utils.TestCheckResourceAttrStartsWith("warpstream_topic.topic", "virtual_cluster_id", "vci_"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config").AtSliceIndex(0).AtMapKey("name"), knownvalue.StringExact("retention.ms")),
+					statecheck.ExpectKnownValue("warpstream_topic.topic", tfjsonpath.New("config").AtSliceIndex(0).AtMapKey("value"), knownvalue.StringExact("1604800000")),
+				},
+			},
+		},
+	})
+}
+
 func TestAccTopicResourceDeletePlan(t *testing.T) {
 	virtualClusterRandString := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
 	virtualClusterName := fmt.Sprintf("vcn_%s", virtualClusterRandString)


### PR DESCRIPTION
Apply would fail when removing - for instance - `warpstream.topic.type` from the config after an apply:

```
 Error: Provider produced inconsistent result after apply                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
        When applying changes to warpstream_topic.topic, provider                                                                                                                                                                                                                                                  
        "provider[\"registry.terraform.io/hashicorp/warpstream\"]" produced an                                                                                                                                                                                                                                     
        unexpected new value: .config: actual set element                                                                                                                                                                                                                                                          
        cty.ObjectVal(map[string]cty.Value{"name":cty.StringVal("warpstream.topic.type"),                                                                                                                                                                                                                          
        "value":cty.StringVal("classic")}) does not correlate with any element in                                                                                                                                                                                                                                  
        plan.                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
        This is a bug in the provider, which should be reported in the provider's own                                                                                                                                                                                                                              
        issue tracker.                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                   
        Error: Provider produced inconsistent result after apply                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
        When applying changes to warpstream_topic.topic, provider                                                                                                                                                                                                                                                  
        "provider[\"registry.terraform.io/hashicorp/warpstream\"]" produced an                                                                                                                                                                                                                                     
        unexpected new value: .config: block set length changed from 1 to 2.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                   
        This is a bug in the provider, which should be reported in the provider's own                                                                                                                                                                                                                              
        issue tracker.                                                      
```