### PR TITLE
fix(pipeline): do not validate inputs when `configuration_yaml` is unknown

### DIFF
--- a/internal/provider/resources/pipeline.go
+++ b/internal/provider/resources/pipeline.go
@@ -186,47 +186,55 @@ func (r *pipelineResource) ValidateConfig(ctx context.Context, req resource.Vali
 		return
 	}
 
-	hasYAML := !config.ConfigurationYAML.IsNull() && !config.ConfigurationYAML.IsUnknown()
-	hasInputs := !config.ConfigurationInputs.IsNull() && !config.ConfigurationInputs.IsUnknown()
+	yamlIsNull := config.ConfigurationYAML.IsNull()
+	yamlIsUnknown := config.ConfigurationYAML.IsUnknown()
+	inputsIsNull := config.ConfigurationInputs.IsNull()
+	inputsIsUnknown := config.ConfigurationInputs.IsUnknown()
+	yamlKnown := !yamlIsUnknown
+	inputsKnown := !inputsIsUnknown
+	hasYAML := !yamlIsNull
+	hasInputs := !inputsIsNull
 
-	if hasYAML && hasInputs {
-		resp.Diagnostics.AddError(
-			"Invalid Pipeline Configuration",
-			"Cannot specify both configuration_yaml and configuration_inputs. Use one or the other.",
-		)
-		return
-	}
-
-	if !hasYAML && !hasInputs {
-		resp.Diagnostics.AddError(
-			"Missing Pipeline Configuration",
-			"Either configuration_yaml or configuration_inputs must be provided.",
-		)
-		return
-	}
-
-	if hasInputs {
-		pipelineType := config.Type.ValueString()
-		// Type defaults to "bento" when not set, but during validation it may be unknown.
-		if !config.Type.IsNull() && !config.Type.IsUnknown() && pipelineType != TableflowPipelineType {
+	if yamlKnown && inputsKnown {
+		if hasYAML && hasInputs {
 			resp.Diagnostics.AddError(
 				"Invalid Pipeline Configuration",
-				"configuration_inputs is only supported for tableflow pipelines. Use configuration_yaml instead.",
+				"Cannot specify both configuration_yaml and configuration_inputs. Use one or the other.",
 			)
 			return
 		}
 
-		for key, elem := range config.ConfigurationInputs.Elements() {
-			strVal, ok := elem.(types.String)
-			if !ok || strVal.IsNull() || strVal.IsUnknown() {
-				continue
-			}
-			if _, err := utils.NormalizeYAML(strVal.ValueString()); err != nil {
-				resp.Diagnostics.AddAttributeError(
-					path.Root("configuration_inputs").AtMapKey(key),
-					"Invalid YAML Value",
-					fmt.Sprintf("The value for key %q is not valid YAML: %s", key, err.Error()),
+		if !hasYAML && !hasInputs {
+			resp.Diagnostics.AddError(
+				"Missing Pipeline Configuration",
+				"Either configuration_yaml or configuration_inputs must be provided.",
+			)
+			return
+		}
+
+		if hasInputs {
+			pipelineType := config.Type.ValueString()
+			// Type defaults to "bento" when not set, but during validation it may be unknown.
+			if !config.Type.IsNull() && !config.Type.IsUnknown() && pipelineType != TableflowPipelineType {
+				resp.Diagnostics.AddError(
+					"Invalid Pipeline Configuration",
+					"configuration_inputs is only supported for tableflow pipelines. Use configuration_yaml instead.",
 				)
+				return
+			}
+
+			for key, elem := range config.ConfigurationInputs.Elements() {
+				strVal, ok := elem.(types.String)
+				if !ok || strVal.IsNull() || strVal.IsUnknown() {
+					continue
+				}
+				if _, err := utils.NormalizeYAML(strVal.ValueString()); err != nil {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("configuration_inputs").AtMapKey(key),
+						"Invalid YAML Value",
+						fmt.Sprintf("The value for key %q is not valid YAML: %s", key, err.Error()),
+					)
+				}
 			}
 		}
 	}

--- a/internal/provider/tests/pipeline_resource_test.go
+++ b/internal/provider/tests/pipeline_resource_test.go
@@ -698,3 +698,35 @@ func TestPipelineResourceImport(t *testing.T) {
 		},
 	})
 }
+
+func TestPipelineResourceConfigurationYAMLFromVariable(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testPipelineConfigYAMLFromVariable(),
+				Check:              testPipelineCheck(resources.TableflowPipelineType),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testPipelineConfigYAMLFromVariable() string {
+	return providerConfig + `
+variable "configuration_yaml" {
+  type    = string
+  default = <<-EOT
+    input: {}
+    output: {}
+  EOT
+}
+resource "warpstream_pipeline" "test_pipeline" {
+  virtual_cluster_id = "vci_1234567890"
+  name               = "test_pipeline"
+  state              = "paused"
+  configuration_yaml = var.configuration_yaml
+}`
+}


### PR DESCRIPTION
Terraform plan was failing with
```
╷
│ Error: Missing Pipeline Configuration
│
│   with warpstream_pipeline.this,
│   on main.tf line 72, in resource "warpstream_pipeline" "this":
│   72: resource "warpstream_pipeline" "this" {
│
│ Either configuration_yaml or configuration_inputs must be provided.
```

When using a `configuration_yaml` defined as a variable, but not when it is defined inline. For ex with:
```
terraform {
  required_providers {
    warpstream = {
      source  = "warpstreamlabs/warpstream"
      version = ">= 2.2.0"
    }
    random = {
      source  = "hashicorp/random"
      version = ">= 3.6.0"
    }
  }
}

provider "warpstream" {
}

variable "configuration_yaml" {
  type    = string
  default = <<-YAML
    input: {}
    output: {}
  YAML
}

resource "warpstream_pipeline" "this" {
  virtual_cluster_id = "vci_1234567890"
  name               = "repro"
  state              = "paused"

  # Bug
  configuration_yaml = var.configuration_yaml

  # # No bug
  # configuration_yaml = <<-YAML
  #   input: {}
  #   output: {}
  # YAML
}
```

That's because for whatever reason, terraform considers some variables to be "unknown" (when they are in a `variable` instead of inlined).

Fix in this PR: do not run the validation only if we are in the "unknown" case.



-----

See original customer message: https://confluent.slack.com/archives/C09TR8D6ETY/p1774911308647379