### PR TITLE
Surface HTTP status and body on retry exhaustion

### DIFF
--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -33,9 +33,9 @@ func NewClient(host string, token *string) (*Client, error) {
 	retryClient.RetryMax = 5
 	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
 		if err == nil {
-			err = fmt.Errorf("%s giving up after %d attempt(s)", resp.Request.URL, numTries)
+			err = fmt.Errorf("%s %s giving up after %d attempt(s)", resp.Request.Method, resp.Request.URL, numTries)
 		} else {
-			err = fmt.Errorf("%s giving up after %d attempt(s): %w", resp.Request.URL, numTries, err)
+			err = fmt.Errorf("%s %s giving up after %d attempt(s): %w", resp.Request.Method, resp.Request.URL, numTries, err)
 		}
 		return resp, err
 	}

--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -31,6 +31,14 @@ type Client struct {
 func NewClient(host string, token *string) (*Client, error) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 5
+	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		if err == nil {
+			err = fmt.Errorf("%s giving up after %d attempt(s)", resp.Request.URL, numTries)
+		} else {
+			err = fmt.Errorf("%s giving up after %d attempt(s): %w", resp.Request.URL, numTries, err)
+		}
+		return resp, err
+	}
 	retryClient.StandardClient().Timeout = 10 * time.Second
 	c := Client{
 		HTTPClient: retryClient,
@@ -74,6 +82,13 @@ func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error)
 
 	res, err := c.HTTPClient.Do(retryReq)
 	if err != nil {
+		if res != nil {
+			defer res.Body.Close()
+			body, readErr := io.ReadAll(res.Body)
+			if readErr == nil {
+				return nil, fmt.Errorf("%w: status: %d, body: %s", err, res.StatusCode, body)
+			}
+		}
 		return nil, err
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
## Summary
- When `go-retryablehttp` exhausts all retries (e.g. repeated 429s), the default error handler discards the HTTP response and returns only a generic "giving up after N attempt(s)" message
- Sets a custom `ErrorHandler` that preserves the last HTTP response and includes the attempt count in the error
- Reads the response status code and body in the `doRequest` error path so it's surfaced to the Terraform user

**Before:** `giving up after 6 attempt(s)`
**After:** `http://.../list_virtual_clusters giving up after 6 attempt(s): status: 429, body: {"error":"rate_limit_exceeded","message":"too many requests, please slow down"}`

## Test plan
- [x] Ran `terraform plan` against a mock server returning 429 — confirmed error now includes status code, response body, and retry count
- [x] Ran `terraform plan` with an invalid API key — confirmed existing 401 handling still works correctly
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)