### PR TITLE
In Events client, replace GET with POST in GetEventsState

### DIFF
--- a/internal/provider/api/api_key.go
+++ b/internal/provider/api/api_key.go
@@ -133,7 +133,7 @@ func (c *Client) createAPIKey(
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_api_key", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_api_key", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (c *Client) DeleteAPIKey(id string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_api_key", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_api_key", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (c *Client) DeleteAPIKey(id string) error {
 
 // GetAPIKeys - Returns list of API keys.
 func (c *Client) GetAPIKeys() ([]APIKey, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/list_api_keys", c.HostURL), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/list_api_keys", c.HostURL), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/api/events_state.go
+++ b/internal/provider/api/events_state.go
@@ -45,7 +45,7 @@ func (c *Client) GetEventsState(vc VirtualCluster) (*EventsState, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/get_events_state", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/get_events_state", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/api/events_state.go
+++ b/internal/provider/api/events_state.go
@@ -45,7 +45,7 @@ func (c *Client) GetEventsState(vc VirtualCluster) (*EventsState, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/get_events_state", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/get_events_state", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *Client) UpdateEventsState(enabled *bool, eventTypes map[string]EventTyp
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/update_events_state", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/update_events_state", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/api/sso_configuration.go
+++ b/internal/provider/api/sso_configuration.go
@@ -52,7 +52,7 @@ func (c *Client) CreateSSOConfiguration(
 		return "", fmt.Errorf("failed to marshal SSO configuration create request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_sso_configuration", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_sso_configuration", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return "", fmt.Errorf("failed to create SSO configuration create request: %w", err)
 	}
@@ -80,7 +80,7 @@ func (c *Client) DeleteSSOConfiguration(id string) error {
 		return fmt.Errorf("failed to marshal SSO configuration delete request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_sso_configuration", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_sso_configuration", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("failed to create SSO configuration delete request: %w", err)
 	}
@@ -104,7 +104,7 @@ func (c *Client) UpdateSSOConfiguration(updateRequest SSOConfigurationUpdateRequ
 		return fmt.Errorf("failed to marshal SSO configuration update request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/update_sso_configuration", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/update_sso_configuration", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("failed to create SSO configuration update request: %w", err)
 	}
@@ -123,7 +123,7 @@ func (c *Client) UpdateSSOConfiguration(updateRequest SSOConfigurationUpdateRequ
 
 // GetSSOConfiguration - Return the current SSO configuration for the tenant if it matches the provided ID.
 func (c *Client) GetSSOConfiguration(ssoConfigurationID string) (*SSOConfiguration, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/get_sso_configuration", c.HostURL), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/get_sso_configuration", c.HostURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SSO configuration get request: %w", err)
 	}
@@ -152,7 +152,7 @@ func (c *Client) GetSSOConfiguration(ssoConfigurationID string) (*SSOConfigurati
 
 // GetSSOConfigurationWithoutID - Return the current SSO configuration for the tenant. Can return nil, nil if none exists.
 func (c *Client) GetSSOConfigurationWithoutID() (*SSOConfiguration, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/get_sso_configuration", c.HostURL), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/get_sso_configuration", c.HostURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SSO configuration get request: %w", err)
 	}

--- a/internal/provider/api/topics.go
+++ b/internal/provider/api/topics.go
@@ -54,7 +54,7 @@ func (c *Client) CreateTopic(virtualClusterID string, topicName string, partitio
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_topic", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_topic", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (c *Client) DescribeTopic(virtualClusterID string, topicName string) (*Topi
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/describe_topic", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/describe_topic", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (c *Client) UpdateTopic(virtualClusterID string, topicName string, partitio
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/update_topic", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/update_topic", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (c *Client) DeleteTopic(virtualClusterID string, topicName string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_topic", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_topic", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/api/user_role.go
+++ b/internal/provider/api/user_role.go
@@ -41,7 +41,7 @@ func (c *Client) CreateUserRole(name string, grants []AccessGrant) (string, erro
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_user_role", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_user_role", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return "", err
 	}
@@ -68,7 +68,7 @@ func (c *Client) UpdateUserRole(id string, name string, grants []AccessGrant) er
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/update_user_role", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/update_user_role", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (c *Client) DeleteUserRole(id string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_user_role", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_user_role", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (c *Client) DeleteUserRole(id string) error {
 
 // getUserRoles - Returns list of User Roles.
 func (c *Client) getUserRoles() ([]UserRole, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/list_user_roles", c.HostURL), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/list_user_roles", c.HostURL), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/api/virtual_cluster.go
+++ b/internal/provider/api/virtual_cluster.go
@@ -155,7 +155,7 @@ func (c *Client) CreateVirtualCluster(name string, opts ClusterParameters) (*Vir
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_virtual_cluster", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_virtual_cluster", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (c *Client) RenameVirtualCluster(id string, newName string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/rename_virtual_cluster", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/rename_virtual_cluster", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (c *Client) DeleteVirtualCluster(id string, name string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_virtual_cluster", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_virtual_cluster", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -238,7 +238,7 @@ func (c *Client) DeleteVirtualCluster(id string, name string) error {
 
 // GetVirtualClusters - Returns list of virtual clusters.
 func (c *Client) GetVirtualClusters() ([]VirtualCluster, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/list_virtual_clusters", c.HostURL), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/list_virtual_clusters", c.HostURL), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (c *Client) UpdateVirtualClusterTier(id string, tier string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/update_virtual_cluster_tier", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/update_virtual_cluster_tier", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/api/virtual_cluster_configuration.go
+++ b/internal/provider/api/virtual_cluster_configuration.go
@@ -71,7 +71,7 @@ func (c *Client) UpdateConfiguration(cfg VirtualClusterConfiguration, vc Virtual
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/update_virtual_cluster_configuration", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/update_virtual_cluster_configuration", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/api/virtual_cluster_credentials.go
+++ b/internal/provider/api/virtual_cluster_credentials.go
@@ -56,7 +56,7 @@ func (c *Client) CreateCredentials(name string, su bool, importedPassword *strin
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_virtual_cluster_credentials", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_virtual_cluster_credentials", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *Client) DeleteCredentials(id string, vc VirtualCluster) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_virtual_cluster_credentials", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_virtual_cluster_credentials", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/api/workspace.go
+++ b/internal/provider/api/workspace.go
@@ -39,7 +39,7 @@ func (c *Client) CreateWorkspace(name string) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/create_workspace", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/create_workspace", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +67,7 @@ func (c *Client) DeleteWorkspace(id string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/delete_workspace", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/delete_workspace", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (c *Client) DeleteWorkspace(id string) error {
 
 // GetWorkspaces - Returns list of Workspaces.
 func (c *Client) GetWorkspaces() ([]Workspace, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/list_workspaces", c.HostURL), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/list_workspaces", c.HostURL), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (c *Client) RenameWorkspace(workspaceID string, newName string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/rename_workspace", c.HostURL), bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/rename_workspace", c.HostURL), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Don't make the Events client build GET requests containing a body.

Also for coding style, replace all HTTP verb string literals with the `http.MethodPost` constant