### PR TITLE
Fix HTTP client retry policy for 499 errors and harden error handling

### DIFF
--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -32,14 +33,21 @@ func NewClient(host string, token *string) (*Client, error) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 5
 	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
-		if err == nil {
-			err = fmt.Errorf("%s %s giving up after %d attempt(s)", resp.Request.Method, resp.Request.URL, numTries)
+		if resp != nil && resp.Request != nil {
+			if err == nil {
+				err = fmt.Errorf("%s %s giving up after %d attempt(s)", resp.Request.Method, resp.Request.URL, numTries)
+			} else {
+				err = fmt.Errorf("%s %s giving up after %d attempt(s): %w", resp.Request.Method, resp.Request.URL, numTries, err)
+			}
+		} else if err == nil {
+			err = fmt.Errorf("giving up after %d attempt(s)", numTries)
 		} else {
-			err = fmt.Errorf("%s %s giving up after %d attempt(s): %w", resp.Request.Method, resp.Request.URL, numTries, err)
+			err = fmt.Errorf("giving up after %d attempt(s): %w", numTries, err)
 		}
 		return resp, err
 	}
-	retryClient.StandardClient().Timeout = 10 * time.Second
+	retryClient.HTTPClient.Timeout = 30 * time.Second
+	retryClient.CheckRetry = checkRetryPolicy
 	c := Client{
 		HTTPClient: retryClient,
 		// Default Warpstream URL
@@ -57,6 +65,24 @@ func NewClient(host string, token *string) (*Client, error) {
 
 	c.Token = *token
 	return &c, nil
+}
+
+// checkRetryPolicy extends the default retry policy to also retry on HTTP 499
+// (client-side cancellation). The WarpStream API returns 499 with
+// "context_canceled" when the server detects the client connection was dropped
+// before the response could be sent. This is transient and safe to retry.
+func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	shouldRetry, checkErr := retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	if shouldRetry {
+		return true, checkErr
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if resp != nil && resp.StatusCode == 499 {
+		return true, nil
+	}
+	return false, checkErr
 }
 
 func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error) {

--- a/internal/provider/api/pipeline.go
+++ b/internal/provider/api/pipeline.go
@@ -168,7 +168,7 @@ func (c *Client) doJSONHTTP(
 	path string,
 	resp any,
 ) error {
-	ctx, cc := context.WithTimeout(ctx, 2*time.Minute)
+	ctx, cc := context.WithTimeout(ctx, 4*time.Minute)
 	defer cc()
 
 	marshaled, err := json.Marshal(&req)

--- a/internal/provider/api/pipeline.go
+++ b/internal/provider/api/pipeline.go
@@ -168,7 +168,7 @@ func (c *Client) doJSONHTTP(
 	path string,
 	resp any,
 ) error {
-	ctx, cc := context.WithTimeout(ctx, 15*time.Second)
+	ctx, cc := context.WithTimeout(ctx, 2*time.Minute)
 	defer cc()
 
 	marshaled, err := json.Marshal(&req)


### PR DESCRIPTION
## Summary

- **Retry on HTTP 499**: The default `go-retryablehttp` policy only retries 429 and 5xx. HTTP 499 (`context_canceled`) is a transient error where the WarpStream API detects the client disconnected before sending a response. This adds a custom `CheckRetry` policy that retries 499 with the existing exponential backoff (up to 5 retries).
- **Fix per-request timeout**: `StandardClient().Timeout` was a no-op because `StandardClient()` returns a new `*http.Client` each call — the timeout was set on a throwaway object. Changed to `HTTPClient.Timeout = 30s` which targets the actual client used by the retry loop.
- **Guard ErrorHandler against nil response**: When all retries fail due to connection-level errors (DNS failure, TCP refused), `resp` is nil. The existing `ErrorHandler` dereferenced `resp.Request` unconditionally, causing a nil pointer panic.
- **Increase `doJSONHTTP` context timeout**: The 15s context timeout conflicted with the retry budget (30s per-attempt + exponential backoff). Increased to 2 minutes to allow the full retry cycle to complete.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/provider/api/...` passes
- [ ] Verify with a WarpStream environment that returns transient 499 errors
- [ ] Confirm no regressions on normal API operations (create/read/delete virtual clusters, credentials, ACLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)