### PR TITLE
fix(client): fix pointer dereference error in error handler

### DIFF
--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -32,10 +32,18 @@ func NewClient(host string, token *string) (*Client, error) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 5
 	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		var (
+			method string
+			url    string
+		)
+		if resp != nil && resp.Request != nil {
+			method = resp.Request.Method
+			url = resp.Request.URL.String()
+		}
 		if err == nil {
-			err = fmt.Errorf("%s %s giving up after %d attempt(s)", resp.Request.Method, resp.Request.URL, numTries)
+			err = fmt.Errorf("%s %s giving up after %d attempt(s)", method, url, numTries)
 		} else {
-			err = fmt.Errorf("%s %s giving up after %d attempt(s): %w", resp.Request.Method, resp.Request.URL, numTries, err)
+			err = fmt.Errorf("%s %s giving up after %d attempt(s): %w", method, url, numTries, err)
 		}
 		return resp, err
 	}


### PR DESCRIPTION
Pointer deref error reported by customer in https://confluent.slack.com/archives/C0B2M4Z0Y6A/p1780422558145769
```
╷
│ Error: Request cancelled
│ 
│ The plugin6.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵
Stack trace from the terraform-provider-warpstream_v2.7.7 plugin:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0xb0d4b1]
goroutine 28 [running]:
github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api.NewClient.func1(0x0, {0x1087d40, 0x17826c0}, 0x2)
    github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api/client.go:38 +0x71
github.com/hashicorp/go-retryablehttp.(*Client).Do(0xc000480880, 0xc0000fc000)
    github.com/hashicorp/go-retryablehttp@v0.7.7/client.go:808 +0xbd9
github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api.(*Client).doRequest(0xc0000c4300, 0xc00041a000, 0x0)
    github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api/client.go:83 +0x3af
github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api.(*Client).doJSONHTTP(0xc0000c4300, {0x1090d88, 0xc000cd6d80}, {0xe8b380, 0xc00199e6e0}, {0xf2d650, 0x1d}, {0xd5a620, 0xc0006455d0})
    github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api/pipeline.go:188 +0x3b1
github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api.(*Client).CreatePipelineConfiguration(0xc0000c4300, {0x1090d88, 0xc000cd6d80}, {{0xc00003abd0, 0x2b}, {0xc00016016c, 0x24}, {0xc000a54000, 0x74b9b}, {0x0, ...}})
    github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/api/pipeline.go:125 +0x8c
github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/resources.(*pipelineResource).Update(0xc00010e1d8, {0x1090d88, 0xc000cd6d80}, {{{{0x10968b0, 0xc000cd7a40}, {0xdfa3a0, 0xc000cd77d0}}, {0x1099618, 0xc0000c60f0}}, {{{0x10968b0, ...}, ...}, ...}, ...}, ...)
    github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/resources/pipeline.go:468 +0x685
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).UpdateResource(0xc000284908, {0x1090d88, 0xc000cd6d80}, 0xc00024d4a8, 0xc00024d480)
    github.com/hashicorp/terraform-plugin-framework@v1.14.1/internal/fwserver/server_updateresource.go:122 +0x6d7
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ApplyResourceChange(0xc000284908, {0x1090d88, 0xc000cd6d80}, 0xc0000c6870, 0xc00024d668)
    github.com/hashicorp/terraform-plugin-framework@v1.14.1/internal/fwserver/server_applyresourcechange.go:102 +0x192
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ApplyResourceChange(0xc000284908, {0x1090d88?, 0xc000cd6c90?}, 0xc0000c67d0)
    github.com/hashicorp/terraform-plugin-framework@v1.14.1/internal/proto6server/server_applyresourcechange.go:55 +0x385
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0xc0002b8be0, {0x1090d88?, 0xc000cd6060?}, 0xc0002aa070)
    github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov6/tf6server/server.go:866 +0x3b9
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0xef5ba0, 0xc0002b8be0}, {0x1090d88, 0xc000cd6060}, 0xc0001bcd80, 0x0)
    github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:611 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002846c8, {0x1090d88, 0xc00017d4d0}, 0xc000454680, 0xc0003939e0, 0x1751f58, 0x0)
    google.golang.org/grpc@v1.79.3/server.go:1429 +0x11e7
google.golang.org/grpc.(*Server).handleStream(0xc0002846c8, {0x10917b8, 0xc000454000}, 0xc000454680)
    google.golang.org/grpc@v1.79.3/server.go:1855 +0xbc6
google.golang.org/grpc.(*Server).serveStreams.func2.1()
    google.golang.org/grpc@v1.79.3/server.go:1064 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 8
    google.golang.org/grpc@v1.79.3/server.go:1075 +0x11d
Error: The terraform-provider-warpstream_v2.7.7 plugin crashed!
This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```