### PR TITLE
Fix HTTP client retry policy for 499 errors

### DIFF
--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -47,7 +48,8 @@ func NewClient(host string, token *string) (*Client, error) {
 		}
 		return resp, err
 	}
-	retryClient.StandardClient().Timeout = 10 * time.Second
+	retryClient.HTTPClient.Timeout = 30 * time.Second
+	retryClient.CheckRetry = checkRetryPolicy
 	c := Client{
 		HTTPClient: retryClient,
 		// Default Warpstream URL
@@ -65,6 +67,24 @@ func NewClient(host string, token *string) (*Client, error) {
 
 	c.Token = *token
 	return &c, nil
+}
+
+// checkRetryPolicy extends the default retry policy to also retry on HTTP 499
+// (client-side cancellation). The WarpStream API returns 499 with
+// "context_canceled" when the server detects the client connection was dropped
+// before the response could be sent. This is transient and safe to retry.
+func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	shouldRetry, checkErr := retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	if shouldRetry {
+		return true, checkErr
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if resp != nil && resp.StatusCode == 499 {
+		return true, nil
+	}
+	return false, checkErr
 }
 
 func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error) {

--- a/internal/provider/api/pipeline.go
+++ b/internal/provider/api/pipeline.go
@@ -168,7 +168,7 @@ func (c *Client) doJSONHTTP(
 	path string,
 	resp any,
 ) error {
-	ctx, cc := context.WithTimeout(ctx, 2*time.Minute)
+	ctx, cc := context.WithTimeout(ctx, 4*time.Minute)
 	defer cc()
 
 	marshaled, err := json.Marshal(&req)

--- a/internal/provider/api/pipeline.go
+++ b/internal/provider/api/pipeline.go
@@ -168,7 +168,7 @@ func (c *Client) doJSONHTTP(
 	path string,
 	resp any,
 ) error {
-	ctx, cc := context.WithTimeout(ctx, 15*time.Second)
+	ctx, cc := context.WithTimeout(ctx, 2*time.Minute)
 	defer cc()
 
 	marshaled, err := json.Marshal(&req)


### PR DESCRIPTION
- **Retry on HTTP 499:** The default go-retryablehttp policy only retries 429 and 5xx. HTTP 499 (`context_canceled`) is a transient error where the WarpStream API detects the client disconnected before sending a response. This adds a custom `CheckRetry` policy that retries 499 with the existing exponential backoff (up to 5 retries).
- **Fix per-request timeout:** `StandardClient().Timeout` was a no-op because `StandardClient()` returns a new `*http.Client` on each call — the 10s timeout was set on a throwaway object. Changed to `HTTPClient.Timeout = 30s`, which targets the client actually used by the retry loop.
- **Increase `doJSONHTTP` context timeout:** The 15s context timeout could expire before the full retry cycle finished (30s per attempt × up to 6 attempts, plus exponential backoff between retries). Increased to 4 minutes so retries are not cut off prematurely.

Copied from [this PR](https://github.com/warpstreamlabs/terraform-provider-warpstream/pull/223) after rebasing and resolving a conflict