### PR TITLE
Set User-Agent header on WarpStream API client requests

### DIFF
--- a/internal/provider/api/acl_test.go
+++ b/internal/provider/api/acl_test.go
@@ -385,7 +385,7 @@ func newACLTestClient(t *testing.T, host string) *Client {
 	t.Helper()
 
 	token := "test-token"
-	client, err := NewClient(host, &token)
+	client, err := NewClient(host, &token, "test")
 	if err != nil {
 		t.Fatalf("NewClient returned error: %v", err)
 	}

--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -20,16 +20,23 @@ var ErrNotFound = errors.New("Resource Not Found")
 // HostURL - Default Warpstream URL.
 const HostURL string = "https://api.prod.us-east-1.warpstream.com/api/v1"
 
+// devVersion is used in the User-Agent for local builds and tests.
+const devVersion string = "dev"
+
 // Client.
 type Client struct {
 	HostURL    string
 	HTTPClient *retryablehttp.Client
 	Token      string
+	UserAgent  string
 	aclsCache  aclsCache
 }
 
 // NewClient.
-func NewClient(host string, token *string) (*Client, error) {
+func NewClient(host string, token *string, version string) (*Client, error) {
+	if version == "" {
+		version = "unset" // should never happen
+	}
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 5
 	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
@@ -53,7 +60,8 @@ func NewClient(host string, token *string) (*Client, error) {
 	c := Client{
 		HTTPClient: retryClient,
 		// Default Warpstream URL
-		HostURL: HostURL,
+		HostURL:   HostURL,
+		UserAgent: fmt.Sprintf("terraform-provider-warpstream/%s", version),
 	}
 
 	if host != "" {
@@ -102,6 +110,7 @@ func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error)
 
 	req.Header.Set("warpstream-api-key", token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
 
 	retryReq, err := retryablehttp.FromRequest(req)
 	if err != nil {
@@ -154,5 +163,5 @@ func NewClientDefault() (*Client, error) {
 	token := os.Getenv("WARPSTREAM_API_KEY")
 	host := os.Getenv("WARPSTREAM_API_URL")
 
-	return NewClient(host, &token)
+	return NewClient(host, &token, devVersion)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -117,7 +117,7 @@ func (p *warpstreamProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	// Create a new WarpStream client using the configuration values
-	client, err := api.NewClient(host, &token)
+	client, err := api.NewClient(host, &token, p.version)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Warpstream API Client",


### PR DESCRIPTION
Internal change to improve observability on the backend