### PR TITLE
Remove event types validation from the virtual cluster resource

### DIFF
--- a/docs/data-sources/virtual_cluster.md
+++ b/docs/data-sources/virtual_cluster.md
@@ -102,7 +102,7 @@ Read-Only:
 Read-Only:
 
 - `enabled` (Boolean)
-- `event_types` (Attributes Map) Per-event-type configuration. Map keys are event type names: `agent_logs`, `pipeline_logs`, `acl_logs`. (see [below for nested schema](#nestedatt--events--event_types))
+- `event_types` (Attributes Map) Per-event-type configuration. Map keys are event type names. (see [below for nested schema](#nestedatt--events--event_types))
 
 <a id="nestedatt--events--event_types"></a>
 ### Nested Schema for `events.event_types`

--- a/docs/resources/virtual_cluster.md
+++ b/docs/resources/virtual_cluster.md
@@ -143,7 +143,7 @@ Optional:
 Optional:
 
 - `enabled` (Boolean) Enable events for this virtual cluster. Defaults to `false`.
-- `event_types` (Attributes Map) Per event type configuration. Map keys can be the names of any supported event type: `agent_logs`, `pipeline_logs`, `acl_logs`. (see [below for nested schema](#nestedatt--events--event_types))
+- `event_types` (Attributes Map) Per event type configuration. Map keys are event type names. Refer to the Events tab of the WarpStream web console for the list of valid event types. (see [below for nested schema](#nestedatt--events--event_types))
 
 <a id="nestedatt--events--event_types"></a>
 ### Nested Schema for `events.event_types`

--- a/internal/provider/datasources/virtual_cluster.go
+++ b/internal/provider/datasources/virtual_cluster.go
@@ -155,7 +155,7 @@ The WarpStream provider must be authenticated with an application key to read th
 						Computed: true,
 					},
 					"event_types": schema.MapNestedAttribute{
-						Description: fmt.Sprintf("Per-event-type configuration. Map keys are event type names: %s.", utils.ValidEventTypeNamesDescription),
+						Description: "Per-event-type configuration. Map keys are event type names.",
 						Computed:    true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{

--- a/internal/provider/resources/virtual_cluster.go
+++ b/internal/provider/resources/virtual_cluster.go
@@ -305,10 +305,9 @@ The WarpStream provider must be authenticated with an application key to consume
 						},
 					},
 					"event_types": schema.MapNestedAttribute{
-						Description: fmt.Sprintf("Per event type configuration. Map keys can be the names of any supported event type: %s.", utils.ValidEventTypeNamesDescription),
+						Description: "Per event type configuration. Map keys are event type names. Refer to the Events tab of the WarpStream web console for the list of valid event types.",
 						Optional:    true,
 						Computed:    true,
-						Validators:  []validator.Map{utils.ValidEventTypeKeys()},
 						PlanModifiers: []planmodifier.Map{
 							mapplanmodifier.UseStateForUnknown(),
 						},

--- a/internal/provider/tests/virtual_cluster_resource_test.go
+++ b/internal/provider/tests/virtual_cluster_resource_test.go
@@ -430,19 +430,6 @@ func TestAccVirtualClusterResourceWithEventTypes(t *testing.T) {
 	})
 }
 
-func TestAccVirtualClusterResourceEventTypesValidation(t *testing.T) {
-	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccVirtualClusterResource_withInvalidEventType(vcNameSuffix),
-				ExpectError: regexp.MustCompile("Invalid Event Type Key"),
-			},
-		},
-	})
-}
-
 func TestAccVirtualClusterResourceEventTypesAllTypes(t *testing.T) {
 	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -514,23 +501,6 @@ resource "warpstream_virtual_cluster" "test" {
       acl_logs = {
         enabled                = true
         retention_period_nanos = 432000000000000
-      }
-    }
-  }
-}`, vcNameSuffix)
-}
-
-func testAccVirtualClusterResource_withInvalidEventType(vcNameSuffix string) string {
-	return providerConfig + fmt.Sprintf(`
-resource "warpstream_virtual_cluster" "test" {
-  name = "vcn_test_acc_%s"
-  tier = "fundamentals"
-  events = {
-    enabled = true
-    event_types = {
-      invalid_event_type = {
-        enabled                = true
-        retention_period_nanos = 86400000000000
       }
     }
   }

--- a/internal/provider/utils/validators.go
+++ b/internal/provider/utils/validators.go
@@ -229,68 +229,6 @@ func BillingGrantConstraint() validator.Object {
 	return billingGrantValidator{}
 }
 
-// ValidEventTypeNames defines the allowed event type names for virtual cluster events.
-var ValidEventTypeNames = []string{"agent_logs", "pipeline_logs", "acl_logs"}
-
-// ValidEventTypeNamesDescription is a formatted string listing the valid event type names for use in schema descriptions.
-var ValidEventTypeNamesDescription string
-
-func init() {
-	quoted := make([]string, len(ValidEventTypeNames))
-	for i, name := range ValidEventTypeNames {
-		quoted[i] = fmt.Sprintf("`%s`", name)
-	}
-	ValidEventTypeNamesDescription = strings.Join(quoted, ", ")
-}
-
-type eventTypeKeysValidator struct {
-	allowedKeys []string
-}
-
-func (v eventTypeKeysValidator) Description(ctx context.Context) string {
-	return fmt.Sprintf("Map keys must be one of: %s", strings.Join(v.allowedKeys, ", "))
-}
-
-func (v eventTypeKeysValidator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
-}
-
-func (v eventTypeKeysValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
-	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
-		return
-	}
-
-	elements := req.ConfigValue.Elements()
-
-	for key := range elements {
-		valid := false
-		for _, allowedKey := range v.allowedKeys {
-			if key == allowedKey {
-				valid = true
-				break
-			}
-		}
-
-		if !valid {
-			resp.Diagnostics.AddAttributeError(
-				req.Path,
-				"Invalid Event Type Key",
-				fmt.Sprintf(
-					"The event type key '%s' is not valid. Valid event types are: %s",
-					key,
-					strings.Join(v.allowedKeys, ", "),
-				),
-			)
-		}
-	}
-}
-
-func ValidEventTypeKeys() validator.Map {
-	return eventTypeKeysValidator{
-		allowedKeys: ValidEventTypeNames,
-	}
-}
-
 // ClientMetricsMatchAllowedParams is the set of selector keys accepted on
 // the left-hand side of each entry in a client metrics subscription `match`
 // string. Mirrors clientMetricsAllowedMatchParams in


### PR DESCRIPTION
Leave validation to the backend so the provider doesn't need to maintain and up-to-date list