### PR TITLE
Add ability to specifiy SR tier

### DIFF
--- a/docs/data-sources/schema_registry.md
+++ b/docs/data-sources/schema_registry.md
@@ -43,6 +43,7 @@ output "vc_sr_by_name_id" {
 - `cloud` (Attributes) (see [below for nested schema](#nestedatt--cloud))
 - `created_at` (String)
 - `id` (String) The ID of this resource.
+- `tier` (String) Virtual Cluster Tier.
 - `workspace_id` (String) Workspace ID. ID of the workspace to which the virtual cluster belongs. Assigned based on the workspace of the application key used to authenticate the WarpStream provider. Cannot be changed after creation.
 
 <a id="nestedatt--agent_keys"></a>

--- a/docs/resources/schema_registry.md
+++ b/docs/resources/schema_registry.md
@@ -30,6 +30,7 @@ provider "warpstream" {
 
 resource "warpstream_schema_registry" "example_schema_registry" {
   name = "vcn_sr_example_schema_registry"
+  tier = "dev"
 }
 ```
 
@@ -43,6 +44,7 @@ resource "warpstream_schema_registry" "example_schema_registry" {
 ### Optional
 
 - `cloud` (Attributes) Virtual Cluster Cloud Location. (see [below for nested schema](#nestedatt--cloud))
+- `tier` (String) Virtual Cluster Tier. Currently, the valid virtual cluster tiers are `dev`, `pro`, `fundamentals`, and `enterprise`. Defaults to `pro`.
 
 ### Read-Only
 

--- a/examples/resources/warpstream_schema_registry/resource.tf
+++ b/examples/resources/warpstream_schema_registry/resource.tf
@@ -12,4 +12,5 @@ provider "warpstream" {
 
 resource "warpstream_schema_registry" "example_schema_registry" {
   name = "vcn_sr_example_schema_registry"
+  tier = "dev"
 }

--- a/internal/provider/datasources/schema_registry.go
+++ b/internal/provider/datasources/schema_registry.go
@@ -54,6 +54,10 @@ The WarpStream provider must be authenticated with an application key to read th
 				Optional:   true,
 				Validators: []validator.String{utils.StartsWithAndAlphanumeric("vcn_sr_")},
 			},
+			"tier": schema.StringAttribute{
+				Description: "Virtual Cluster Tier.",
+				Computed:    true,
+			},
 			"agent_keys": schema.ListNestedAttribute{
 				Description:  "List of keys to authenticate an agent with this cluster.",
 				Computed:     true,
@@ -126,6 +130,7 @@ func (d *schemaRegistryDataSource) Read(ctx context.Context, req datasource.Read
 	state := models.SchemaRegistryDataSource{
 		ID:          types.StringValue(vc.ID),
 		Name:        types.StringValue(vc.Name),
+		Tier:        types.StringValue(vc.Tier),
 		AgentKeys:   agentKeys,
 		CreatedAt:   types.StringValue(vc.CreatedAt),
 		Cloud:       data.Cloud,

--- a/internal/provider/models/schema_registry.go
+++ b/internal/provider/models/schema_registry.go
@@ -8,6 +8,7 @@ import (
 type SchemaRegistryDataSource struct {
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
+	Tier         types.String `tfsdk:"tier"`
 	AgentKeys    *[]AgentKey  `tfsdk:"agent_keys"`
 	CreatedAt    types.String `tfsdk:"created_at"`
 	Cloud        types.Object `tfsdk:"cloud"`
@@ -18,6 +19,7 @@ type SchemaRegistryDataSource struct {
 type SchemaRegistryResource struct {
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
+	Tier         types.String `tfsdk:"tier"`
 	CreatedAt    types.String `tfsdk:"created_at"`
 	Cloud        types.Object `tfsdk:"cloud"`
 	BootstrapURL types.String `tfsdk:"bootstrap_url"`

--- a/internal/provider/resources/schema_registry.go
+++ b/internal/provider/resources/schema_registry.go
@@ -116,6 +116,23 @@ The WarpStream provider must be authenticated with an application key to consume
 				},
 				Validators: []validator.String{utils.ValidSchemaRegistryName()},
 			},
+			"tier": schema.StringAttribute{
+				Description: "Virtual Cluster Tier. Currently, the valid virtual cluster tiers are `dev`, `pro`, `fundamentals`, and `enterprise`. Defaults to `pro`.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(api.VirtualClusterTierPro),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						api.VirtualClusterTierDev,
+						api.VirtualClusterTierFundamentals,
+						api.VirtualClusterTierPro,
+						api.VirtualClusterTierEnterprise,
+					),
+				},
+			},
 			"created_at": schema.StringAttribute{
 				Description: "Virtual Cluster Creation Timestamp.",
 				Computed:    true,
@@ -156,7 +173,7 @@ func (r *schemaRegistryResource) Create(ctx context.Context, req resource.Create
 		plan.Name.ValueString(),
 		api.ClusterParameters{
 			Type:   api.VirtualClusterTypeSchemaRegistry,
-			Tier:   api.VirtualClusterTierPro,
+			Tier:   plan.Tier.ValueString(),
 			Region: cloudPlan.Region.ValueStringPointer(),
 			Cloud:  cloudPlan.Provider.ValueString(),
 		})
@@ -180,6 +197,7 @@ func (r *schemaRegistryResource) Create(ctx context.Context, req resource.Create
 	state := models.SchemaRegistryResource{
 		ID:          types.StringValue(cluster.ID),
 		Name:        types.StringValue(cluster.Name),
+		Tier:        types.StringValue(cluster.Tier),
 		CreatedAt:   types.StringValue(cluster.CreatedAt),
 		Cloud:       plan.Cloud,
 		WorkspaceID: types.StringValue(cluster.WorkspaceID),
@@ -244,6 +262,7 @@ func (r *schemaRegistryResource) Read(ctx context.Context, req resource.ReadRequ
 
 	state.ID = types.StringValue(cluster.ID)
 	state.Name = types.StringValue(cluster.Name)
+	state.Tier = types.StringValue(cluster.Tier)
 	state.WorkspaceID = types.StringValue(cluster.WorkspaceID)
 	state.CreatedAt = types.StringValue(cluster.CreatedAt)
 	if cluster.BootstrapURL != nil {
@@ -272,11 +291,43 @@ func (r *schemaRegistryResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 func (r *schemaRegistryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan models.VirtualClusterResource
+	var plan models.SchemaRegistryResource
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	var state models.SchemaRegistryResource
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Update tier if changed
+	if !plan.Tier.Equal(state.Tier) {
+		err := r.client.UpdateVirtualClusterTier(state.ID.ValueString(), plan.Tier.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Updating WarpStream Schema Registry Tier",
+				"Could not update WarpStream Schema Registry Tier, unexpected error: "+err.Error(),
+			)
+			return
+		}
+
+		// Read back the updated cluster to get the new tier
+		cluster, err := r.client.GetVirtualCluster(state.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading WarpStream Virtual Cluster after tier update",
+				"Could not read WarpStream Virtual Cluster ID "+state.ID.ValueString()+": "+err.Error(),
+			)
+			return
+		}
+
+		diags = resp.State.SetAttribute(ctx, path.Root("tier"), types.StringValue(cluster.Tier))
+		resp.Diagnostics.Append(diags...)
 	}
 }
 

--- a/internal/provider/tests/pipeline_resource_test.go
+++ b/internal/provider/tests/pipeline_resource_test.go
@@ -328,6 +328,7 @@ func testSchemaMigratorPipeline() string {
 	virtualClusterResource := fmt.Sprintf(`
 resource "warpstream_schema_registry" "test" {
   name = "vcn_sr_test_%s"
+  tier = "dev"
 }`, acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	return providerConfig + virtualClusterResource + `
 resource "warpstream_pipeline" "test_pipeline" {

--- a/internal/provider/tests/schema_registry_data_source_test.go
+++ b/internal/provider/tests/schema_registry_data_source_test.go
@@ -17,11 +17,12 @@ func TestAccSchemaRegistryDataSource(t *testing.T) {
 
 	vcNameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
 	region := "us-east-1"
+	tier := api.VirtualClusterTierFundamentals
 	vc, err := client.CreateVirtualCluster(
 		vcNameSuffix,
 		api.ClusterParameters{
 			Type:   api.VirtualClusterTypeSchemaRegistry,
-			Tier:   api.VirtualClusterTierPro,
+			Tier:   tier,
 			Region: &region,
 			Cloud:  "aws",
 		},
@@ -43,7 +44,7 @@ func TestAccSchemaRegistryDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testSchemaRegistryDataSourceWithIDAndAgentKey(vc.ID, agentKeyName),
-				Check:  testAccSchemaRegistryDatasourceCheck(vc, datasourceName, agentKeyName),
+				Check:  testAccSchemaRegistryDatasourceCheck(vc, datasourceName, agentKeyName, tier),
 			},
 		},
 	})
@@ -83,12 +84,13 @@ func testAccSchemaRegistryDatasourceCheck(
 	vc *api.VirtualCluster,
 	datasourceName string,
 	agentKeyName string,
+	expectedTier string,
 ) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttrSet(datasourceName, "id"),
 		resource.TestCheckResourceAttr(datasourceName, "id", vc.ID),
 		resource.TestCheckResourceAttrSet(datasourceName, "created_at"),
-		resource.TestCheckResourceAttr(datasourceName, "tier", vc.Tier),
+		resource.TestCheckResourceAttr(datasourceName, "tier", expectedTier),
 		resource.TestCheckResourceAttr(datasourceName, "cloud.provider", "aws"),
 		resource.TestCheckResourceAttr(datasourceName, "cloud.region", "us-east-1"),
 		resource.TestCheckResourceAttr(datasourceName, "agent_keys.#", "1"),

--- a/internal/provider/tests/schema_registry_data_source_test.go
+++ b/internal/provider/tests/schema_registry_data_source_test.go
@@ -88,6 +88,7 @@ func testAccSchemaRegistryDatasourceCheck(
 		resource.TestCheckResourceAttrSet(datasourceName, "id"),
 		resource.TestCheckResourceAttr(datasourceName, "id", vc.ID),
 		resource.TestCheckResourceAttrSet(datasourceName, "created_at"),
+		resource.TestCheckResourceAttr(datasourceName, "tier", vc.Tier),
 		resource.TestCheckResourceAttr(datasourceName, "cloud.provider", "aws"),
 		resource.TestCheckResourceAttr(datasourceName, "cloud.region", "us-east-1"),
 		resource.TestCheckResourceAttr(datasourceName, "agent_keys.#", "1"),

--- a/internal/provider/tests/schema_registry_resource_test.go
+++ b/internal/provider/tests/schema_registry_resource_test.go
@@ -16,6 +16,7 @@ func testSchemaRegistryResource(nameSuffix string) string {
 	return providerConfig + fmt.Sprintf(`
 resource "warpstream_schema_registry" "test" {
   name = "vcn_sr_test_%s"
+  tier = "dev"
 }`, nameSuffix)
 }
 
@@ -71,6 +72,8 @@ func testCheckSchemaRegistry(resourceName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
 		resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+		resource.TestCheckResourceAttrSet(resourceName, "tier"),
+		resource.TestCheckResourceAttr(resourceName, "tier", "dev"),
 		resource.TestCheckResourceAttr(resourceName, "cloud.provider", "aws"),
 		resource.TestCheckResourceAttr(resourceName, "cloud.region", "us-east-1"),
 		utils.TestCheckResourceAttrStartsWith(resourceName, "id", "vci_sr_"),


### PR DESCRIPTION
This adds a `tier` option to the `warpstream_schema_registry` resource to allow people to configure the cluster tier for their schema registry clusters. Note that prior to this all schema registry clusters created with terraform default to the `pro` tier. So for backwards-compatibility the `tier` option is optional with `pro` as the default.