### PR TITLE
Fix get SSO NPE

### DIFF
--- a/internal/provider/datasources/sso_configuration.go
+++ b/internal/provider/datasources/sso_configuration.go
@@ -79,6 +79,13 @@ func (d *ssoConfigurationDataSource) Read(ctx context.Context, req datasource.Re
 		resp.Diagnostics.AddError("Unable to Read WarpStream SSO configuration", err.Error())
 		return
 	}
+	if ssoConfig == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read WarpStream SSO configuration",
+			"No SSO configuration found for this tenant.",
+		)
+		return
+	}
 
 	data.ID = types.StringValue(ssoConfig.ID)
 	data.EnableSSORoleMapping = types.BoolValue(ssoConfig.EnableSSORoleMapping)


### PR DESCRIPTION
Fixes

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xebb06e]

goroutine 210 [running]:
github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/datasources.(*ssoConfigurationDataSource).Read(0x18479af1c240, {0x12b3810, 0x18479ae766f0}, {{{{0x12be368, 0x18479ae76e70}, {0x10c14c0, 0x18479ae76e40}}, {0x12c19b8, 0x18479b17e1c0}}, {{{0x0, ...}, ...}, ...}, ...}, ...)
	/home/runner/work/terraform-provider-warpstream/terraform-provider-warpstream/internal/provider/datasources/sso_configuration.go:83 +0x20e
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ReadDataSource(0x18479b163448, {0x12b3810, 0x18479ae766f0}, 0x18479b12fbc0, 0x18479b109648)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.14.1/internal/fwserver/server_readdatasource.go:103 +0x79a
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ReadDataSource(0x18479b163448, {0x12b3810?, 0x18479ae76570?}, 0x18479ae76540)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.14.1/internal/proto6server/server_readdatasource.go:55 +0x3e6
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadDataSource(0x18479b0d7cc0, {0x12b3810?, 0x18479b0ab950?}, 0x18479b114230)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov6/tf6server/server.go:688 +0x26a
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadDataSource_Handler({0x11f3000, 0x18479b0d7cc0}, {0x12b3810, 0x18479b0ab950}, 0x18479adb9c80, 0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:665 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0x18479b163688, {0x12b3810, 0x18479b0ab8c0}, 0x18479acbbba0, 0x18479acc37d0, 0x1c9a680, 0x0)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.79.3/server.go:1429 +0x11dc
google.golang.org/grpc.(*Server).handleStream(0x18479b163688, {0x12b4850, 0x18479adbc9c0}, 0x18479acbbba0)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.79.3/server.go:1855 +0xbc6
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.79.3/server.go:1064 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 184
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.79.3/server.go:1075 +0x11d
FAIL	github.com/warpstreamlabs/terraform-provider-warpstream/internal/provider/tests	1.468s
```

According to the `GetSSOConfigurationWithoutID` [doc string](https://github.com/warpstreamlabs/terraform-provider-warpstream/blob/52616af024c04a72a0cb0fbfeb9060f26dcdd48a/internal/provider/api/sso_configuration.go#L153) the function "Can return nil, nil if none exists" so we should check for nilness first before accessing the response fields. Most likely this only happens in tests, but is good to guard against dereferencing nils in general. 